### PR TITLE
Hour 5: two-pass analyze flow (PRD §11)

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,16 +1,32 @@
 import { NextResponse } from "next/server";
+import { parseAnalyzeRequest } from "@/lib/request.ts";
+import { analyze } from "@/lib/analyze.ts";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
 export async function POST(req: Request) {
-  const body = await req.json().catch(() => ({}));
-  return NextResponse.json(
-    {
-      ok: true,
-      received: body,
-      note: "Stub. Two-pass analyze flow lands in Hour 5 (PRD §11).",
-    },
-    { status: 200 },
-  );
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = parseAnalyzeRequest(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  try {
+    const outcome = await analyze(parsed.value);
+    return NextResponse.json(outcome, { status: 200 });
+  } catch (err) {
+    const message = (err as Error).message;
+    console.error("[analyze] failed:", message);
+    return NextResponse.json(
+      { error: "Analysis failed", detail: message },
+      { status: 500 },
+    );
+  }
 }

--- a/data/law-to-file-id.json
+++ b/data/law-to-file-id.json
@@ -1,0 +1,3 @@
+{
+  "_comment": "STUB. Empty until scripts/python/prep_corpus.py ingest writes the real map. While empty, every Vertex retrieval throws 'No Vertex file ID mapped for Law N', which lib/retrieval/index.ts catches and routes to the fallback path."
+}

--- a/lib/analyze.ts
+++ b/lib/analyze.ts
@@ -1,0 +1,124 @@
+// PRD §11 two-pass analyze flow.
+// The route handler is a thin wrapper; this is the actual pipeline.
+
+import { GoogleGenAI } from "@google/genai";
+import type { AnalyzeRequest } from "./request.ts";
+import { INCIDENT_TO_LAW } from "./types.ts";
+import type { IncidentType, VerdictResponse } from "./types.ts";
+import { uploadCloudinaryToGemini, deleteUploaded } from "./gemini/upload.ts";
+import { runPass1 } from "./gemini/pass1.ts";
+import { runPass2 } from "./gemini/pass2.ts";
+import { retrieve } from "./retrieval/index.ts";
+import { applyValidation, shortCircuitInconclusive } from "./validation.ts";
+import { deriveReviewMode } from "./confidence.ts";
+
+export interface AnalyzeOutcome {
+  response: VerdictResponse;
+  flags: string[];
+  promptVersion: string;
+}
+
+export async function analyze(req: AnalyzeRequest): Promise<AnalyzeOutcome> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error("GEMINI_API_KEY not set");
+  const ai = new GoogleGenAI({ apiKey });
+
+  // (1) Upload Cloudinary clip to Gemini File API. Reused across both passes.
+  const clip = await uploadCloudinaryToGemini(ai, req.cloudinaryUrl);
+
+  try {
+    // (2) Pass 1 (skipped if user supplied a manual incident type).
+    let incidentType: IncidentType;
+    let isSoccerClip = true;
+    let keyMomentTimestamp = "00:00";
+    let searchTerms: string[] = [];
+
+    if (req.incidentType === "auto_detect") {
+      const p1 = await runPass1(ai, clip);
+      isSoccerClip = p1.is_soccer_clip;
+      incidentType = p1.incident_type;
+      keyMomentTimestamp = p1.key_moment_timestamp;
+      searchTerms = p1.search_terms;
+    } else {
+      incidentType = req.incidentType;
+    }
+
+    // (3) Short-circuits per PRD §11.4 field notes.
+    if (!isSoccerClip) {
+      return {
+        response: shortCircuitInconclusive({
+          isSoccerClip: false,
+          detectedIncidentType: "unknown",
+          originalDecision: req.originalDecision,
+          reason: "Clip does not appear to be soccer.",
+          keyMomentTimestamp,
+        }),
+        flags: ["short-circuit:not-soccer"],
+        promptVersion: "p1.0.0",
+      };
+    }
+
+    if (incidentType === "unsupported" || incidentType === "unknown") {
+      const reason =
+        incidentType === "unsupported"
+          ? "This kind of decision usually requires context the clip cannot provide."
+          : "The disputed incident could not be classified from the clip.";
+      return {
+        response: shortCircuitInconclusive({
+          isSoccerClip: true,
+          detectedIncidentType: incidentType,
+          originalDecision: req.originalDecision,
+          reason,
+          keyMomentTimestamp,
+        }),
+        flags: [`short-circuit:${incidentType}`],
+        promptVersion: "p1.0.0",
+      };
+    }
+
+    // (4) Map incident → law. Deterministic lookup (PRD §6).
+    const lawNumber = INCIDENT_TO_LAW[incidentType];
+    if (!lawNumber) {
+      // Defensive — the only entries with null mapping are unsupported/unknown,
+      // and we already returned above for those. Treat as inconclusive.
+      return {
+        response: shortCircuitInconclusive({
+          isSoccerClip: true,
+          detectedIncidentType: incidentType,
+          originalDecision: req.originalDecision,
+          reason: `No law mapped for incident type ${incidentType}`,
+          keyMomentTimestamp,
+        }),
+        flags: ["short-circuit:no-law-mapping"],
+        promptVersion: "p1.0.0",
+      };
+    }
+
+    // (5) Retrieve scoped to the mapped law.
+    const queryText = searchTerms.length > 0 ? searchTerms.join(" ") : `${incidentType} ${lawNumber}`;
+    const retrieval = await retrieve(lawNumber, queryText, { topK: 5 });
+
+    // (6) Pass 2 with retrieved chunks.
+    const reviewMode = deriveReviewMode(req.originalDecision);
+    const raw = await runPass2(ai, {
+      clip,
+      incidentType,
+      lawNumber,
+      retrievedChunks: retrieval.chunks,
+      originalDecision: req.originalDecision,
+      reviewMode,
+    });
+
+    // (7) Run validation pipeline (PRD §11.7).
+    const { response, flags } = applyValidation(raw, {
+      retrievalSource: retrieval.source,
+      retrievedChunks: retrieval.chunks,
+      originalDecision: req.originalDecision,
+    });
+
+    return { response, flags, promptVersion: "p1.0.0" };
+  } finally {
+    // Best-effort cleanup; never throws.
+    await deleteUploaded(ai, clip.name);
+  }
+}

--- a/lib/confidence.ts
+++ b/lib/confidence.ts
@@ -1,4 +1,4 @@
-import type { Confidence, EvidenceQuality, ReviewMode, OriginalRefereeDecision } from "./types";
+import type { Confidence, EvidenceQuality, ReviewMode, OriginalRefereeDecision } from "./types.ts";
 
 // PRD §11.5: confidence is derived from evidence quality, NOT the model's self-rating.
 // The model's `confidence` field is overwritten by this function before returning.

--- a/lib/gemini/pass1.ts
+++ b/lib/gemini/pass1.ts
@@ -1,0 +1,63 @@
+// PRD §11.3 Pass 1 — classification. Default FPS=1 (no timing precision needed).
+
+import { GoogleGenAI, createPartFromUri, createUserContent } from "@google/genai";
+import type { IncidentType } from "../types.ts";
+import type { UploadedClip } from "./upload.ts";
+import { pass1ClassificationPrompt } from "./prompts.ts";
+import { tryParseModelJson } from "../validation.ts";
+
+const MODEL = "gemini-2.5-flash";
+
+export interface Pass1Result {
+  is_soccer_clip: boolean;
+  incident_type: IncidentType;
+  key_moment_timestamp: string;
+  search_terms: string[];
+}
+
+const VALID_INCIDENT_TYPES = new Set<IncidentType>([
+  "foul",
+  "handball",
+  "offside",
+  "penalty_kick",
+  "free_kick",
+  "throw_in",
+  "goal_kick",
+  "corner_kick",
+  "ball_in_out",
+  "unsupported",
+  "unknown",
+]);
+
+export async function runPass1(
+  ai: GoogleGenAI,
+  clip: UploadedClip,
+): Promise<Pass1Result> {
+  const response = await ai.models.generateContent({
+    model: MODEL,
+    contents: createUserContent([
+      createPartFromUri(clip.uri, clip.mimeType),
+      pass1ClassificationPrompt(),
+    ]),
+  });
+
+  const text = response.text ?? "";
+  const parsed = tryParseModelJson(text);
+  if (!parsed.ok) {
+    throw new Error(`Pass 1 returned non-JSON: ${parsed.reason}; raw: ${text.slice(0, 200)}`);
+  }
+
+  const v = parsed.value as Partial<Pass1Result>;
+  if (typeof v.is_soccer_clip !== "boolean") {
+    throw new Error(`Pass 1 missing is_soccer_clip: ${text.slice(0, 200)}`);
+  }
+  if (typeof v.incident_type !== "string" || !VALID_INCIDENT_TYPES.has(v.incident_type as IncidentType)) {
+    throw new Error(`Pass 1 invalid incident_type: ${String(v.incident_type)}`);
+  }
+  return {
+    is_soccer_clip: v.is_soccer_clip,
+    incident_type: v.incident_type as IncidentType,
+    key_moment_timestamp: typeof v.key_moment_timestamp === "string" ? v.key_moment_timestamp : "00:00",
+    search_terms: Array.isArray(v.search_terms) ? v.search_terms.filter((s) => typeof s === "string") : [],
+  };
+}

--- a/lib/gemini/pass2.ts
+++ b/lib/gemini/pass2.ts
@@ -1,0 +1,71 @@
+// PRD §11.3 Pass 2 — verdict. Per-incident FPS via videoMetadata (PRD §9).
+
+import { GoogleGenAI, createUserContent } from "@google/genai";
+import type { IncidentType, OriginalRefereeDecision, ReviewMode, VerdictResponse } from "../types.ts";
+import { PASS_2_FPS } from "../types.ts";
+import type { UploadedClip } from "./upload.ts";
+import type { RetrievedChunk } from "../retrieval/types.ts";
+import { pass2VerdictPrompt } from "./prompts.ts";
+import { tryParseModelJson, looksLikeVerdictResponse } from "../validation.ts";
+
+const MODEL = "gemini-2.5-flash";
+
+export interface Pass2Args {
+  clip: UploadedClip;
+  incidentType: IncidentType;
+  lawNumber: string;
+  retrievedChunks: RetrievedChunk[];
+  originalDecision: OriginalRefereeDecision;
+  reviewMode: ReviewMode;
+}
+
+export async function runPass2(ai: GoogleGenAI, args: Pass2Args): Promise<VerdictResponse> {
+  const fps = PASS_2_FPS[args.incidentType] ?? 1;
+
+  // Per PRD §9, FPS varies per incident via videoMetadata on the Part.
+  const videoPart = {
+    fileData: { fileUri: args.clip.uri, mimeType: args.clip.mimeType },
+    videoMetadata: { fps },
+  };
+
+  const prompt = pass2VerdictPrompt({
+    incidentType: args.incidentType,
+    lawNumber: args.lawNumber,
+    retrievedChunks: args.retrievedChunks,
+    originalDecision: args.originalDecision,
+    reviewMode: args.reviewMode,
+  });
+
+  // First attempt.
+  let response = await ai.models.generateContent({
+    model: MODEL,
+    contents: createUserContent([videoPart, prompt]),
+  });
+  let text = response.text ?? "";
+  let parsed = tryParseModelJson(text);
+
+  // Per PRD §11.7 step 1: retry once with a stricter JSON-only repair prompt.
+  if (!parsed.ok || !looksLikeVerdictResponse(parsed.value)) {
+    const repairPrompt = [
+      "Your previous response was not a valid JSON object matching the required schema.",
+      "Return ONLY the JSON object, no prose, no markdown fences.",
+      "Original prompt follows:",
+      "",
+      prompt,
+    ].join("\n");
+    response = await ai.models.generateContent({
+      model: MODEL,
+      contents: createUserContent([videoPart, repairPrompt]),
+    });
+    text = response.text ?? "";
+    parsed = tryParseModelJson(text);
+  }
+
+  if (!parsed.ok) {
+    throw new Error(`Pass 2 unparseable after retry: ${parsed.reason}; raw: ${text.slice(0, 300)}`);
+  }
+  if (!looksLikeVerdictResponse(parsed.value)) {
+    throw new Error(`Pass 2 schema mismatch: ${text.slice(0, 300)}`);
+  }
+  return parsed.value;
+}

--- a/lib/gemini/prompts.ts
+++ b/lib/gemini/prompts.ts
@@ -1,0 +1,116 @@
+// Prompt strings live in code (PRD §11.8). They are iterated against the
+// test set in PRD §12 — keep deltas small and version-tagged so eval results
+// stay comparable.
+
+import type { IncidentType, OriginalRefereeDecision } from "../types.ts";
+import type { RetrievedChunk } from "../retrieval/types.ts";
+
+export const PROMPT_VERSION = "p1.0.0";
+
+// ---------------------------------------------------------------------------
+// Pass 1 — classification. Tiny, no rule text, no schema baggage.
+// ---------------------------------------------------------------------------
+export function pass1ClassificationPrompt(): string {
+  return [
+    "You are reviewing a short soccer video clip.",
+    "Decide if the clip appears to be soccer, identify the single most disputed incident, and classify it.",
+    "",
+    "Return ONLY a JSON object with this exact shape, no prose, no markdown fences:",
+    "{",
+    '  "is_soccer_clip": boolean,',
+    '  "incident_type": "foul" | "handball" | "offside" | "penalty_kick" | "free_kick" | "throw_in" | "goal_kick" | "corner_kick" | "ball_in_out" | "unsupported" | "unknown",',
+    '  "key_moment_timestamp": "MM:SS",',
+    '  "search_terms": ["short", "phrases", "describing", "what", "matters"]',
+    "}",
+    "",
+    "Rules:",
+    "- If the clip is not soccer, set is_soccer_clip:false and incident_type:\"unknown\".",
+    "- If the disputed incident is something we do not handle (e.g. weather, equipment, timing), set incident_type:\"unsupported\".",
+    "- search_terms should be 3 to 8 short phrases that capture the rule angle (e.g. \"second-last defender\", \"deliberate handball\", \"goalkeeper off line\").",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Pass 2 — verdict. Includes the retrieved chunks and the full output schema.
+// ---------------------------------------------------------------------------
+export interface Pass2PromptArgs {
+  incidentType: IncidentType;
+  lawNumber: string;
+  retrievedChunks: RetrievedChunk[];
+  originalDecision: OriginalRefereeDecision;
+  reviewMode: "call_review" | "rule_assessment";
+}
+
+export function pass2VerdictPrompt(args: Pass2PromptArgs): string {
+  const chunkBlock = args.retrievedChunks.length
+    ? args.retrievedChunks
+        .map(
+          (c, i) =>
+            `[chunk ${i + 1}, id="${c.id}", section="${c.section}"]\n${c.text}`,
+        )
+        .join("\n\n")
+    : "(no chunks retrieved)";
+
+  const schema = [
+    "{",
+    '  "is_soccer_clip": boolean,',
+    '  "detected_incident_type": "foul" | "handball" | "offside" | "penalty_kick" | "free_kick" | "throw_in" | "goal_kick" | "corner_kick" | "ball_in_out" | "unsupported" | "unknown",',
+    '  "original_referee_decision": same value passed in by the user,',
+    '  "review_mode": "call_review" | "rule_assessment",',
+    '  "verdict": "correct_call" | "bad_call" | "inconclusive",',
+    '  "confidence": "low" | "medium" | "high",',
+    '  "key_moment_timestamp": "MM:SS",',
+    '  "what_happened": "One sentence describing the visible incident.",',
+    '  "retrieval_source": leave as "vertex" — the server overwrites this,',
+    '  "rule_applied": {',
+    '    "law_number": string e.g. "Law 11",',
+    '    "law_title": string,',
+    '    "section": string,',
+    '    "retrieved_chunk_ids": [chunk ids you actually used],',
+    '    "quoted_rule": verbatim excerpt from one of the retrieved chunks (≥20 chars)',
+    "  },",
+    '  "reasoning": [5 short steps mapping evidence to rule and to the original decision],',
+    '  "evidence_quality": {',
+    '    "camera_angle": "clear" | "partial" | "obstructed",',
+    '    "key_moment_visible": boolean,',
+    '    "ball_visible_when_needed": boolean,',
+    '    "players_visible_when_needed": boolean,',
+    '    "field_lines_visible_when_needed": boolean,',
+    '    "frame_rate_adequate": boolean,',
+    '    "required_context_missing": [list any context you cannot see in the clip],',
+    '    "issues": [list visibility issues]',
+    "  },",
+    '  "review_limitations": [list anything that limits certainty]',
+    "}",
+  ].join("\n");
+
+  const reviewModeNotice =
+    args.reviewMode === "rule_assessment"
+      ? "REVIEW MODE: rule_assessment. The user did not provide the original referee decision. Return verdict:\"inconclusive\" and explain the likely rule application without saying the call was right or wrong."
+      : `REVIEW MODE: call_review. The original referee decision was: "${args.originalDecision}". Compare your rule analysis against that decision.`;
+
+  return [
+    "You are RefCheck AI, a rule-grounded second-review assistant for soccer referee decisions.",
+    "",
+    `Incident type: ${args.incidentType}`,
+    `Applicable law: ${args.lawNumber}`,
+    "",
+    "RETRIEVED RULE PASSAGES (cite only from these — do not paraphrase from memory):",
+    "----- BEGIN PASSAGES -----",
+    chunkBlock,
+    "----- END PASSAGES -----",
+    "",
+    reviewModeNotice,
+    "",
+    "Output requirements:",
+    "- Return ONLY a JSON object matching the schema below. No prose, no markdown fences.",
+    "- quoted_rule must be a verbatim excerpt copied from one of the retrieved chunks above. Minimum 20 characters.",
+    "- retrieved_chunk_ids must list the chunk ids (e.g. \"law-11-offside-position\") you actually used.",
+    "- If the retrieved chunks do not address the visible incident, return verdict:\"inconclusive\".",
+    "- Populate evidence_quality based ONLY on what is visible. Do not infer visibility from the original decision.",
+    "- reasoning is exactly 5 short steps: (1) identify incident, (2) identify rule from chunks, (3) explain visible evidence, (4) compare evidence to rule, (5) compare rule analysis to original decision.",
+    "",
+    "Schema:",
+    schema,
+  ].join("\n");
+}

--- a/lib/gemini/upload.ts
+++ b/lib/gemini/upload.ts
@@ -5,7 +5,11 @@
 import { GoogleGenAI } from "@google/genai";
 
 const POLL_INTERVAL_MS = 2_000;
-const POLL_TIMEOUT_MS = 90_000;
+// Route maxDuration is 60s. Budget: ~30s for upload+poll, ~30s for Pass 1 +
+// retrieval + Pass 2. If a clip takes longer than 30s to process, we'd rather
+// fail fast and fall back to a cached demo response than starve the rest of
+// the pipeline.
+const POLL_TIMEOUT_MS = 30_000;
 
 export interface UploadedClip {
   name: string;

--- a/lib/gemini/upload.ts
+++ b/lib/gemini/upload.ts
@@ -10,6 +10,12 @@ const POLL_INTERVAL_MS = 2_000;
 // fail fast and fall back to a cached demo response than starve the rest of
 // the pipeline.
 const POLL_TIMEOUT_MS = 30_000;
+// Hard cap on the byte size we'll buffer into memory before handing off to
+// the Gemini File API. PRD §7 caps user uploads at 30s; even high-bitrate
+// 30s clips comfortably fit under 25 MB. A misconfigured Cloudinary preset
+// or a long demo clip could push past this; better to fail with a clear
+// error than OOM the Netlify Function.
+const MAX_VIDEO_BYTES = 25 * 1024 * 1024;
 
 export interface UploadedClip {
   name: string;
@@ -25,7 +31,22 @@ export async function uploadCloudinaryToGemini(
   if (!resp.ok) {
     throw new Error(`Failed to fetch Cloudinary URL (${resp.status}): ${cloudinaryUrl}`);
   }
+  // Size guard before buffering. Cloudinary returns Content-Length on video
+  // delivery URLs; if it's missing we fall through to the streaming check
+  // below.
+  const declaredLength = Number(resp.headers.get("content-length") ?? 0);
+  if (declaredLength && declaredLength > MAX_VIDEO_BYTES) {
+    throw new Error(
+      `Video is too large (${declaredLength} bytes). Please upload a shorter clip.`,
+    );
+  }
   const arrayBuffer = await resp.arrayBuffer();
+  // Defensive check in case Content-Length was absent or wrong.
+  if (arrayBuffer.byteLength > MAX_VIDEO_BYTES) {
+    throw new Error(
+      `Video is too large (${arrayBuffer.byteLength} bytes). Please upload a shorter clip.`,
+    );
+  }
   // Blob is supported in @google/genai's Node upload path; lets us avoid a
   // /tmp file write inside the Netlify Function.
   const blob = new Blob([arrayBuffer], { type: "video/mp4" });

--- a/lib/gemini/upload.ts
+++ b/lib/gemini/upload.ts
@@ -1,0 +1,66 @@
+// Upload a Cloudinary-hosted MP4 to the Gemini File API and wait for it to
+// become ACTIVE. The same file handle is then reused across Pass 1 and Pass 2
+// (PRD §9 — avoids double-uploading).
+
+import { GoogleGenAI } from "@google/genai";
+
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS = 90_000;
+
+export interface UploadedClip {
+  name: string;
+  uri: string;
+  mimeType: string;
+}
+
+export async function uploadCloudinaryToGemini(
+  ai: GoogleGenAI,
+  cloudinaryUrl: string,
+): Promise<UploadedClip> {
+  const resp = await fetch(cloudinaryUrl);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch Cloudinary URL (${resp.status}): ${cloudinaryUrl}`);
+  }
+  const arrayBuffer = await resp.arrayBuffer();
+  // Blob is supported in @google/genai's Node upload path; lets us avoid a
+  // /tmp file write inside the Netlify Function.
+  const blob = new Blob([arrayBuffer], { type: "video/mp4" });
+
+  const uploaded = await ai.files.upload({
+    file: blob,
+    config: { mimeType: "video/mp4" },
+  });
+  if (!uploaded.name) throw new Error("Gemini upload returned no file name");
+
+  const start = Date.now();
+  let current = uploaded;
+  while (current.state === "PROCESSING") {
+    if (Date.now() - start > POLL_TIMEOUT_MS) {
+      throw new Error(`Timeout waiting for Gemini file ${current.name} to become ACTIVE`);
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    current = await ai.files.get({ name: current.name as string });
+  }
+
+  if (current.state === "FAILED") {
+    throw new Error(`Gemini file processing FAILED: ${current.name}`);
+  }
+  if (!current.uri || !current.mimeType) {
+    throw new Error(`Gemini file ready but missing uri/mimeType: ${current.name}`);
+  }
+
+  return {
+    name: current.name as string,
+    uri: current.uri,
+    mimeType: current.mimeType,
+  };
+}
+
+export async function deleteUploaded(ai: GoogleGenAI, name: string): Promise<void> {
+  try {
+    await ai.files.delete({ name });
+  } catch (e) {
+    // Cleanup is best-effort; never throw from here.
+    console.warn(`[gemini] delete ${name} failed: ${(e as Error).message}`);
+  }
+}

--- a/lib/request.test.ts
+++ b/lib/request.test.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseAnalyzeRequest } from "./request.ts";
+
+const validBody = {
+  cloudinaryUrl: "https://res.cloudinary.com/demo/video/upload/v1/sample.mp4",
+  originalDecision: "penalty_awarded",
+  incidentType: "auto_detect",
+};
+
+test("parseAnalyzeRequest accepts a valid Cloudinary URL", () => {
+  const r = parseAnalyzeRequest(validBody);
+  assert.equal(r.ok, true);
+});
+
+test("parseAnalyzeRequest accepts custom subdomain on cloudinary.com", () => {
+  const r = parseAnalyzeRequest({
+    ...validBody,
+    cloudinaryUrl: "https://my-cloud.cloudinary.com/video/upload/v1/sample.mp4",
+  });
+  assert.equal(r.ok, true);
+});
+
+test("parseAnalyzeRequest rejects non-Cloudinary hosts", () => {
+  const r = parseAnalyzeRequest({
+    ...validBody,
+    cloudinaryUrl: "https://evil.example.com/video.mp4",
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.error, /Cloudinary/i);
+});
+
+test("parseAnalyzeRequest rejects look-alike hostnames", () => {
+  // Endpoint rejects "cloudinary.com.evil.com" — endsWith(".cloudinary.com")
+  // is what we check, and the trailing label matters.
+  const r = parseAnalyzeRequest({
+    ...validBody,
+    cloudinaryUrl: "https://cloudinary.com.evil.com/video.mp4",
+  });
+  assert.equal(r.ok, false);
+});
+
+test("parseAnalyzeRequest rejects URLs without protocol", () => {
+  const r = parseAnalyzeRequest({
+    ...validBody,
+    cloudinaryUrl: "res.cloudinary.com/demo/video.mp4",
+  });
+  assert.equal(r.ok, false);
+});
+
+test("parseAnalyzeRequest rejects unknown originalDecision", () => {
+  const r = parseAnalyzeRequest({ ...validBody, originalDecision: "made_up" });
+  assert.equal(r.ok, false);
+});
+
+test("parseAnalyzeRequest rejects unknown incidentType", () => {
+  const r = parseAnalyzeRequest({ ...validBody, incidentType: "made_up" });
+  assert.equal(r.ok, false);
+});
+
+test("parseAnalyzeRequest rejects missing fields", () => {
+  const r = parseAnalyzeRequest({});
+  assert.equal(r.ok, false);
+});
+
+test("parseAnalyzeRequest rejects non-object input", () => {
+  assert.equal(parseAnalyzeRequest(null).ok, false);
+  assert.equal(parseAnalyzeRequest("string").ok, false);
+  assert.equal(parseAnalyzeRequest(42).ok, false);
+});

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -53,9 +53,27 @@ export function parseAnalyzeRequest(raw: unknown): ParseResult {
   if (typeof r.cloudinaryUrl !== "string" || r.cloudinaryUrl.length === 0) {
     return { ok: false, error: "cloudinaryUrl is required and must be a non-empty string" };
   }
-  // Lightweight URL sanity check; full validation happens at upload time.
-  if (!/^https?:\/\//.test(r.cloudinaryUrl)) {
-    return { ok: false, error: "cloudinaryUrl must be an http(s) URL" };
+  // Restrict to Cloudinary CDN hosts. Without this, the analyze function
+  // becomes a generic SSRF-style "fetch arbitrary URL and feed to Gemini"
+  // primitive. Cloudinary serves video from res.cloudinary.com (and the
+  // legacy cloudinary.com domain), both of which we accept.
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(r.cloudinaryUrl);
+  } catch {
+    return { ok: false, error: "cloudinaryUrl is not a valid URL" };
+  }
+  if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+    return { ok: false, error: "cloudinaryUrl must use http or https" };
+  }
+  const host = parsedUrl.hostname.toLowerCase();
+  const isCloudinary =
+    host === "res.cloudinary.com" ||
+    host.endsWith(".res.cloudinary.com") ||
+    host === "cloudinary.com" ||
+    host.endsWith(".cloudinary.com");
+  if (!isCloudinary) {
+    return { ok: false, error: "cloudinaryUrl must be a Cloudinary CDN URL" };
   }
 
   if (typeof r.originalDecision !== "string" ||

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -1,0 +1,82 @@
+// Request body shape for POST /api/analyze.
+// Manually validated (no zod dep — PRD calls for a lightweight scaffold).
+
+import type { IncidentType, OriginalRefereeDecision } from "./types.ts";
+
+const VALID_INCIDENT_TYPES: ReadonlyArray<IncidentType | "auto_detect"> = [
+  "auto_detect",
+  "foul",
+  "handball",
+  "offside",
+  "penalty_kick",
+  "free_kick",
+  "throw_in",
+  "goal_kick",
+  "corner_kick",
+  "ball_in_out",
+];
+
+const VALID_ORIGINAL_DECISIONS: ReadonlyArray<OriginalRefereeDecision> = [
+  "foul_called",
+  "no_foul_called",
+  "penalty_awarded",
+  "no_penalty_awarded",
+  "offside_called",
+  "goal_allowed",
+  "goal_disallowed",
+  "throw_in_awarded",
+  "goal_kick_awarded",
+  "corner_kick_awarded",
+  "free_kick_awarded",
+  "yellow_card_given",
+  "red_card_given",
+  "unknown",
+];
+
+export interface AnalyzeRequest {
+  cloudinaryUrl: string;
+  originalDecision: OriginalRefereeDecision;
+  incidentType: IncidentType | "auto_detect";
+  promptVersion?: string;
+}
+
+export type ParseResult =
+  | { ok: true; value: AnalyzeRequest }
+  | { ok: false; error: string };
+
+export function parseAnalyzeRequest(raw: unknown): ParseResult {
+  if (typeof raw !== "object" || raw === null) {
+    return { ok: false, error: "request body must be an object" };
+  }
+  const r = raw as Record<string, unknown>;
+
+  if (typeof r.cloudinaryUrl !== "string" || r.cloudinaryUrl.length === 0) {
+    return { ok: false, error: "cloudinaryUrl is required and must be a non-empty string" };
+  }
+  // Lightweight URL sanity check; full validation happens at upload time.
+  if (!/^https?:\/\//.test(r.cloudinaryUrl)) {
+    return { ok: false, error: "cloudinaryUrl must be an http(s) URL" };
+  }
+
+  if (typeof r.originalDecision !== "string" ||
+      !VALID_ORIGINAL_DECISIONS.includes(r.originalDecision as OriginalRefereeDecision)) {
+    return { ok: false, error: `originalDecision must be one of: ${VALID_ORIGINAL_DECISIONS.join(", ")}` };
+  }
+
+  if (typeof r.incidentType !== "string" ||
+      !VALID_INCIDENT_TYPES.includes(r.incidentType as IncidentType | "auto_detect")) {
+    return { ok: false, error: `incidentType must be one of: ${VALID_INCIDENT_TYPES.join(", ")}` };
+  }
+
+  const promptVersion = typeof r.promptVersion === "string" ? r.promptVersion : undefined;
+
+  return {
+    ok: true,
+    value: {
+      cloudinaryUrl: r.cloudinaryUrl,
+      originalDecision: r.originalDecision as OriginalRefereeDecision,
+      incidentType: r.incidentType as IncidentType | "auto_detect",
+      promptVersion,
+    },
+  };
+}

--- a/lib/retrieval/fallback.test.ts
+++ b/lib/retrieval/fallback.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { retrieveFromFallback, _setFallbackCacheForTesting } from "./fallback.ts";
+
+const synthetic = [
+  {
+    id: "a",
+    law_number: "Law 11",
+    law_title: "Offside",
+    section: "Position",
+    text: "A player is in an offside position if any part of the head, body or feet is nearer to the opponents' goal line than both the ball and the second-last opponent.",
+  },
+  {
+    id: "b",
+    law_number: "Law 11",
+    law_title: "Offside",
+    section: "Offence",
+    text: "A player is only penalised when interfering with play, interfering with an opponent, or gaining an advantage.",
+  },
+  {
+    id: "c",
+    law_number: "Law 11",
+    law_title: "Offside",
+    section: "No offence",
+    text: "There is no offside offence if the player receives the ball directly from a goal kick, throw-in, or corner kick.",
+  },
+  {
+    id: "d",
+    law_number: "Law 12",
+    law_title: "Fouls",
+    section: "Direct free kick",
+    text: "A direct free kick is awarded for kicking, tripping, or charging an opponent.",
+  },
+];
+
+test("retrieveFromFallback filters by law_number", () => {
+  _setFallbackCacheForTesting(synthetic);
+  const r = retrieveFromFallback("Law 12", 5);
+  assert.equal(r.source, "fallback");
+  assert.equal(r.chunks.length, 1);
+  assert.equal(r.chunks[0].id, "d");
+});
+
+test("retrieveFromFallback ranks by keyword overlap", () => {
+  _setFallbackCacheForTesting(synthetic);
+  // Query about goal kick / corner kick should rank record "c" first.
+  const r = retrieveFromFallback("Law 11", 3, "goal kick corner kick throw-in");
+  assert.equal(r.chunks[0].id, "c");
+});
+
+test("retrieveFromFallback falls back to document order on empty query", () => {
+  _setFallbackCacheForTesting(synthetic);
+  const r = retrieveFromFallback("Law 11", 3, "");
+  assert.deepEqual(r.chunks.map((c) => c.id), ["a", "b", "c"]);
+});
+
+test("retrieveFromFallback respects k", () => {
+  _setFallbackCacheForTesting(synthetic);
+  const r = retrieveFromFallback("Law 11", 2);
+  assert.equal(r.chunks.length, 2);
+});
+
+test("retrieveFromFallback returns empty for unmatched law", () => {
+  _setFallbackCacheForTesting(synthetic);
+  const r = retrieveFromFallback("Law 99", 5);
+  assert.equal(r.chunks.length, 0);
+});

--- a/lib/retrieval/fallback.test.ts
+++ b/lib/retrieval/fallback.test.ts
@@ -65,3 +65,42 @@ test("retrieveFromFallback returns empty for unmatched law", () => {
   const r = retrieveFromFallback("Law 99", 5);
   assert.equal(r.chunks.length, 0);
 });
+
+// Integration: exercise the real curated corpus from data/ifab-rules-fallback.json.
+// This proves the file shipped with the PR loads, parses, and produces the
+// chunks the validation pipeline expects. Without this, an empty Vertex
+// law-to-file-id.json followed by a malformed fallback file would crash the
+// API at runtime even though all unit tests pass.
+test("retrieveFromFallback loads real curated corpus from disk", () => {
+  // null clears the test cache so loadFallback() reads the real JSON file.
+  _setFallbackCacheForTesting(null);
+
+  // Spot-check each of the 8 supported laws returns at least one chunk
+  // with non-stub content. Iterate so a missing law fails the test loudly.
+  const supportedLaws = [
+    "Law 9",
+    "Law 11",
+    "Law 12",
+    "Law 13",
+    "Law 14",
+    "Law 15",
+    "Law 16",
+    "Law 17",
+  ];
+  for (const lawNumber of supportedLaws) {
+    const r = retrieveFromFallback(lawNumber, 5, "");
+    assert.ok(r.chunks.length > 0, `${lawNumber} produced no chunks from real corpus`);
+    for (const chunk of r.chunks) {
+      assert.equal(chunk.law_number, lawNumber);
+      assert.ok(chunk.text.length > 0, `${chunk.id} has empty text`);
+      assert.ok(
+        !chunk.text.includes("STUB CONTENT"),
+        `${chunk.id} still has STUB CONTENT — fallback not curated`,
+      );
+      assert.ok(
+        !chunk.id.startsWith("STUB-"),
+        `${chunk.id} still has STUB- prefix`,
+      );
+    }
+  }
+});

--- a/lib/retrieval/fallback.ts
+++ b/lib/retrieval/fallback.ts
@@ -1,0 +1,53 @@
+// PRD §11.3 fallback retrieval — keyword filter over local static JSON.
+// No embeddings. Filter by law_number, return first k records in document order.
+// Used as a circuit breaker when Vertex retrieval fails, AND as the primary path
+// per ship-or-cut item #9 if Vertex setup blocks before the demo.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { RetrievalResult, RetrievedChunk } from "./types.ts";
+
+interface FallbackRecord {
+  id: string;
+  law_number: string;
+  law_title: string;
+  section: string;
+  text: string;
+}
+
+let cache: FallbackRecord[] | null = null;
+
+function loadFallback(): FallbackRecord[] {
+  if (cache) return cache;
+  // process.cwd() at function runtime in Netlify is the function's bundle root,
+  // and netlify.toml's `included_files` puts data/ next to the function.
+  const path = join(process.cwd(), "data", "ifab-rules-fallback.json");
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`ifab-rules-fallback.json must be a JSON array, got ${typeof parsed}`);
+  }
+  cache = parsed as FallbackRecord[];
+  return cache;
+}
+
+export function retrieveFromFallback(lawNumber: string, k: number): RetrievalResult {
+  const records = loadFallback();
+  const matches: RetrievedChunk[] = records
+    .filter((r) => r.law_number === lawNumber)
+    .slice(0, k)
+    .map((r) => ({
+      id: r.id,
+      law_number: r.law_number,
+      law_title: r.law_title,
+      section: r.section,
+      text: r.text,
+    }));
+  return { source: "fallback", chunks: matches };
+}
+
+// Test seam: lets unit tests inject a synthetic fallback dataset without
+// needing to write a real ifab-rules-fallback.json on disk.
+export function _setFallbackCacheForTesting(records: FallbackRecord[] | null): void {
+  cache = records;
+}

--- a/lib/retrieval/fallback.ts
+++ b/lib/retrieval/fallback.ts
@@ -31,18 +31,56 @@ function loadFallback(): FallbackRecord[] {
   return cache;
 }
 
-export function retrieveFromFallback(lawNumber: string, k: number): RetrievalResult {
+// Tokenize a query string into lowercased word terms ≥3 chars. We strip
+// stopwords because "and", "the", "of" overlap with everything in the rules
+// text and would flatten the score distribution.
+const STOPWORDS = new Set([
+  "the", "and", "for", "with", "from", "that", "this", "any", "all", "are",
+  "was", "were", "has", "have", "had", "but", "not", "into", "out", "off",
+  "over", "under", "when", "while", "must", "should", "would", "could",
+]);
+
+function tokenizeQuery(q: string): string[] {
+  return q
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+function scoreRecord(record: FallbackRecord, terms: string[]): number {
+  if (terms.length === 0) return 0;
+  const haystack = `${record.section} ${record.text}`.toLowerCase();
+  let score = 0;
+  for (const term of terms) {
+    if (haystack.includes(term)) score += 1;
+  }
+  return score;
+}
+
+export function retrieveFromFallback(
+  lawNumber: string,
+  k: number,
+  queryText = "",
+): RetrievalResult {
   const records = loadFallback();
-  const matches: RetrievedChunk[] = records
-    .filter((r) => r.law_number === lawNumber)
-    .slice(0, k)
-    .map((r) => ({
-      id: r.id,
-      law_number: r.law_number,
-      law_title: r.law_title,
-      section: r.section,
-      text: r.text,
-    }));
+  const candidates = records.filter((r) => r.law_number === lawNumber);
+  const terms = tokenizeQuery(queryText);
+
+  // Score by keyword overlap; preserve document order on ties.
+  const scored = candidates.map((r, idx) => ({
+    record: r,
+    score: scoreRecord(r, terms),
+    idx,
+  }));
+  scored.sort((a, b) => b.score - a.score || a.idx - b.idx);
+
+  const matches: RetrievedChunk[] = scored.slice(0, k).map(({ record }) => ({
+    id: record.id,
+    law_number: record.law_number,
+    law_title: record.law_title,
+    section: record.section,
+    text: record.text,
+  }));
   return { source: "fallback", chunks: matches };
 }
 

--- a/lib/retrieval/index.ts
+++ b/lib/retrieval/index.ts
@@ -23,7 +23,7 @@ export async function retrieve(
   const topK = opts.topK ?? 5;
 
   if (opts.forceFallback) {
-    return retrieveFromFallback(lawNumber, topK);
+    return retrieveFromFallback(lawNumber, topK, queryText);
   }
 
   try {
@@ -32,7 +32,7 @@ export async function retrieve(
     console.warn(
       `[retrieval] Vertex failed for ${lawNumber}, using fallback. Reason: ${(err as Error).message}`,
     );
-    return retrieveFromFallback(lawNumber, topK);
+    return retrieveFromFallback(lawNumber, topK, queryText);
   }
 }
 

--- a/lib/retrieval/index.ts
+++ b/lib/retrieval/index.ts
@@ -1,0 +1,39 @@
+// Public entry point for retrieval.
+// Tries Vertex first; on any failure, falls back to the local static JSON.
+// Logs the failure reason so we can tell from production logs whether Vertex
+// is consistently broken (in which case promote fallback to primary, per
+// PRD §16 ship-or-cut #9).
+
+import { retrieveFromVertex } from "./vertex.ts";
+import { retrieveFromFallback } from "./fallback.ts";
+import type { RetrievalResult } from "./types.ts";
+
+export interface RetrieveOpts {
+  topK?: number;
+  // If true, skip Vertex entirely. Useful for local dev without GCP creds,
+  // and for the demo escape hatch when Vertex is rate-limited.
+  forceFallback?: boolean;
+}
+
+export async function retrieve(
+  lawNumber: string,
+  queryText: string,
+  opts: RetrieveOpts = {},
+): Promise<RetrievalResult> {
+  const topK = opts.topK ?? 5;
+
+  if (opts.forceFallback) {
+    return retrieveFromFallback(lawNumber, topK);
+  }
+
+  try {
+    return await retrieveFromVertex(lawNumber, queryText, { topK });
+  } catch (err) {
+    console.warn(
+      `[retrieval] Vertex failed for ${lawNumber}, using fallback. Reason: ${(err as Error).message}`,
+    );
+    return retrieveFromFallback(lawNumber, topK);
+  }
+}
+
+export type { RetrievalResult, RetrievedChunk } from "./types.ts";

--- a/lib/retrieval/types.ts
+++ b/lib/retrieval/types.ts
@@ -1,0 +1,20 @@
+// Common retrieval shape so Vertex and fallback paths return the same thing.
+
+import type { RetrievalSource } from "../types.ts";
+
+export interface RetrievedChunk {
+  // Stable identifier the model can cite. Vertex returns its own chunk ids;
+  // the fallback path uses the `id` field from data/ifab-rules-fallback.json.
+  id: string;
+  law_number: string;
+  law_title: string;
+  section: string;
+  text: string;
+  // Vertex returns a similarity score; fallback path leaves this null.
+  score?: number;
+}
+
+export interface RetrievalResult {
+  source: RetrievalSource;
+  chunks: RetrievedChunk[];
+}

--- a/lib/retrieval/vertex.ts
+++ b/lib/retrieval/vertex.ts
@@ -100,6 +100,11 @@ export async function retrieveFromVertex(
   if (!tokenResp) throw new Error("Failed to obtain Vertex access token");
 
   const url = `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}:retrieveContexts`;
+  // Body shape verified against
+  //   https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/rag-api-v1
+  // - vertex_rag_store is a TOP-LEVEL sibling of query (not nested in query)
+  // - field names are snake_case in the v1 REST body
+  // - top_k goes in query.rag_retrieval_config.top_k
   const body = {
     vertex_rag_store: {
       rag_resources: [
@@ -111,8 +116,6 @@ export async function retrieveFromVertex(
     },
     query: {
       text: queryText,
-      // top_k goes in rag_retrieval_config in some versions of the API.
-      // We send it both ways to be safe; unknown fields are ignored.
       rag_retrieval_config: { top_k: topK },
     },
   };

--- a/lib/retrieval/vertex.ts
+++ b/lib/retrieval/vertex.ts
@@ -1,0 +1,172 @@
+// PRD §11.3 Vertex AI RAG Engine retrieval, scoped via rag_file_ids.
+//
+// We call the REST endpoint directly because @google-cloud/aiplatform's Node
+// SDK does not surface retrieveContexts. Auth via google-auth-library, with
+// the service account JSON inlined in GOOGLE_APPLICATION_CREDENTIALS_JSON
+// (Netlify Functions can't read a credentials file path).
+//
+// Endpoint:
+//   POST https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT}/locations/{LOCATION}:retrieveContexts
+//
+// Body shape (verified against
+//   https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/rag-api):
+//   {
+//     "vertex_rag_store": {
+//       "rag_resources": [{
+//         "rag_corpus": "projects/.../ragCorpora/...",
+//         "rag_file_ids": ["projects/.../ragFiles/..."]
+//       }]
+//     },
+//     "query": { "text": "..." }
+//   }
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { GoogleAuth } from "google-auth-library";
+import type { RetrievalResult, RetrievedChunk } from "./types.ts";
+
+let authClient: GoogleAuth | null = null;
+
+function getAuth(): GoogleAuth {
+  if (authClient) return authClient;
+  const credsJson = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
+  if (!credsJson) {
+    throw new Error("GOOGLE_APPLICATION_CREDENTIALS_JSON not set");
+  }
+  const credentials = JSON.parse(credsJson);
+  authClient = new GoogleAuth({
+    credentials,
+    scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+  });
+  return authClient;
+}
+
+let lawToFileIdCache: Record<string, string> | null = null;
+
+function loadLawToFileId(): Record<string, string> {
+  if (lawToFileIdCache) return lawToFileIdCache;
+  const path = join(process.cwd(), "data", "law-to-file-id.json");
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("law-to-file-id.json must be a JSON object");
+  }
+  lawToFileIdCache = parsed as Record<string, string>;
+  return lawToFileIdCache;
+}
+
+export interface VertexRetrieveOptions {
+  topK?: number;
+}
+
+export interface VertexRetrievalChunk {
+  // The Vertex response shape varies slightly between regions and versions; we
+  // normalize the few fields we care about. Keeping the raw chunk around in
+  // case the eval script wants to inspect scores.
+  text: string;
+  source_uri?: string;
+  source_display_name?: string;
+  score?: number;
+}
+
+interface RetrieveContextsResponse {
+  contexts?: {
+    contexts?: VertexRetrievalChunk[];
+  };
+}
+
+export async function retrieveFromVertex(
+  lawNumber: string,
+  queryText: string,
+  options: VertexRetrieveOptions = {},
+): Promise<RetrievalResult> {
+  const project = process.env.GOOGLE_CLOUD_PROJECT;
+  const location = process.env.VERTEX_LOCATION;
+  const corpusId = process.env.RAG_CORPUS_ID;
+  if (!project || !location || !corpusId) {
+    throw new Error("Missing one of: GOOGLE_CLOUD_PROJECT, VERTEX_LOCATION, RAG_CORPUS_ID");
+  }
+
+  const map = loadLawToFileId();
+  const fileId = map[lawNumber];
+  if (!fileId) {
+    throw new Error(`No Vertex file ID mapped for ${lawNumber} in law-to-file-id.json`);
+  }
+
+  const topK = options.topK ?? 5;
+
+  const auth = getAuth();
+  const tokenResp = await auth.getAccessToken();
+  if (!tokenResp) throw new Error("Failed to obtain Vertex access token");
+
+  const url = `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}:retrieveContexts`;
+  const body = {
+    vertex_rag_store: {
+      rag_resources: [
+        {
+          rag_corpus: corpusId,
+          rag_file_ids: [fileId],
+        },
+      ],
+    },
+    query: {
+      text: queryText,
+      // top_k goes in rag_retrieval_config in some versions of the API.
+      // We send it both ways to be safe; unknown fields are ignored.
+      rag_retrieval_config: { top_k: topK },
+    },
+  };
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tokenResp}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const errText = await resp.text();
+    throw new Error(`Vertex retrieveContexts failed (${resp.status}): ${errText.slice(0, 500)}`);
+  }
+
+  const json = (await resp.json()) as RetrieveContextsResponse;
+  const rawChunks = json.contexts?.contexts ?? [];
+
+  const chunks: RetrievedChunk[] = rawChunks.map((c, i) => ({
+    // Vertex doesn't expose a stable per-chunk id in the retrieve response,
+    // so we synthesize one from the file ID and chunk index. Stable for the
+    // duration of one retrieval call, which is all the validator needs.
+    id: `${lawNumber.toLowerCase().replace(/\s+/g, "-")}-chunk-${i}`,
+    law_number: lawNumber,
+    law_title: deriveLawTitle(lawNumber),
+    section: c.source_display_name ?? "Retrieved passage",
+    text: c.text ?? "",
+    score: typeof c.score === "number" ? c.score : undefined,
+  }));
+
+  return { source: "vertex", chunks };
+}
+
+// Map Law N → human title for the response object. Kept here (not in §6's
+// types.ts map) because the title is presentation-only.
+const LAW_TITLES: Record<string, string> = {
+  "Law 9": "The Ball In and Out of Play",
+  "Law 11": "Offside",
+  "Law 12": "Fouls and Misconduct",
+  "Law 13": "Free Kicks",
+  "Law 14": "The Penalty Kick",
+  "Law 15": "The Throw-in",
+  "Law 16": "The Goal Kick",
+  "Law 17": "The Corner Kick",
+};
+
+function deriveLawTitle(lawNumber: string): string {
+  return LAW_TITLES[lawNumber] ?? lawNumber;
+}
+
+// Test seam.
+export function _setLawMapForTesting(map: Record<string, string> | null): void {
+  lawToFileIdCache = map;
+}

--- a/lib/validation.test.ts
+++ b/lib/validation.test.ts
@@ -7,6 +7,7 @@ import {
   tryParseModelJson,
   validateChunkIds,
   quotedRuleAppearsInChunks,
+  normalizeForQuoteMatch,
   applyValidation,
   looksLikeVerdictResponse,
   shortCircuitInconclusive,
@@ -93,6 +94,40 @@ test("quotedRuleAppearsInChunks rejects fabricated long quotes", () => {
     sampleChunks,
   );
   assert.equal(found, false);
+});
+
+test("normalizeForQuoteMatch handles smart quotes and em-dashes", () => {
+  const a = normalizeForQuoteMatch("“interfering” — active play");
+  const b = normalizeForQuoteMatch("\"interfering\" - active play");
+  assert.equal(a, b);
+});
+
+test("normalizeForQuoteMatch strips soft hyphens (PDF artifact)", () => {
+  const norm = normalizeForQuoteMatch("inter­fering with play");
+  assert.equal(norm, "interfering with play");
+});
+
+test("normalizeForQuoteMatch NFKC-normalizes ligatures", () => {
+  // The "ﬁ" (U+FB01) ligature should normalize to "fi"
+  const norm = normalizeForQuoteMatch("ﬁnal pass");
+  assert.equal(norm, "final pass");
+});
+
+test("quotedRuleAppearsInChunks tolerates smart-quote rewrites", () => {
+  const chunksWithSmartQuote: RetrievedChunk[] = [
+    {
+      id: "x",
+      law_number: "Law 12",
+      law_title: "Fouls",
+      section: "Misconduct",
+      text: "The referee may caution a player who shows “dissent by word or action” toward an official.",
+    },
+  ];
+  const found = quotedRuleAppearsInChunks(
+    'shows "dissent by word or action" toward an official',
+    chunksWithSmartQuote,
+  );
+  assert.equal(found, true);
 });
 
 function baseGoodResponse(): VerdictResponse {

--- a/lib/validation.test.ts
+++ b/lib/validation.test.ts
@@ -1,0 +1,220 @@
+// Run with: node --test lib/**/*.test.ts
+// Node 24 strips types natively.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  tryParseModelJson,
+  validateChunkIds,
+  quotedRuleAppearsInChunks,
+  applyValidation,
+  looksLikeVerdictResponse,
+  shortCircuitInconclusive,
+} from "./validation.ts";
+import type { RetrievedChunk } from "./retrieval/types.ts";
+import type { VerdictResponse } from "./types.ts";
+
+const sampleChunks: RetrievedChunk[] = [
+  {
+    id: "law-11-offside-offence",
+    law_number: "Law 11",
+    law_title: "Offside",
+    section: "Offside offence",
+    text: "A player in an offside position at the moment the ball is played by a teammate is only penalised on becoming involved in active play by interfering with play, interfering with an opponent, or gaining an advantage by being in that position.",
+  },
+  {
+    id: "law-11-offside-position",
+    law_number: "Law 11",
+    law_title: "Offside",
+    section: "Offside position",
+    text: "A player is in an offside position if any part of the head, body or feet is in the opponents' half (excluding the halfway line) and any part of the head, body or feet is nearer to the opponents' goal line than both the ball and the second-last opponent.",
+  },
+];
+
+test("tryParseModelJson parses plain JSON", () => {
+  const r = tryParseModelJson('{"a":1}');
+  assert.equal(r.ok, true);
+  if (r.ok) assert.deepEqual(r.value, { a: 1 });
+});
+
+test("tryParseModelJson strips markdown fences", () => {
+  const r = tryParseModelJson('```json\n{"a":1}\n```');
+  assert.equal(r.ok, true);
+});
+
+test("tryParseModelJson returns reason on bad JSON", () => {
+  const r = tryParseModelJson("not json");
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.reason, /JSON|token/i);
+});
+
+test("validateChunkIds passes when all ids are known", () => {
+  const r = validateChunkIds(["law-11-offside-offence"], sampleChunks);
+  assert.equal(r.allKnown, true);
+  assert.deepEqual(r.unknownIds, []);
+});
+
+test("validateChunkIds flags hallucinated ids", () => {
+  const r = validateChunkIds(["law-11-offside-offence", "made-up-id"], sampleChunks);
+  assert.equal(r.allKnown, false);
+  assert.deepEqual(r.unknownIds, ["made-up-id"]);
+});
+
+test("validateChunkIds tolerates empty array (no citation)", () => {
+  const r = validateChunkIds([], sampleChunks);
+  assert.equal(r.allKnown, true);
+});
+
+test("quotedRuleAppearsInChunks finds verbatim long quote", () => {
+  const found = quotedRuleAppearsInChunks(
+    "is only penalised on becoming involved in active play by interfering with play",
+    sampleChunks,
+  );
+  assert.equal(found, true);
+});
+
+test("quotedRuleAppearsInChunks normalizes whitespace", () => {
+  const found = quotedRuleAppearsInChunks(
+    "is only penalised   on   becoming\ninvolved in active play",
+    sampleChunks,
+  );
+  assert.equal(found, true);
+});
+
+test("quotedRuleAppearsInChunks rejects too-short quotes", () => {
+  // Under 20 chars is too low-signal; even if it matches, return false.
+  const found = quotedRuleAppearsInChunks("the ball", sampleChunks);
+  assert.equal(found, false);
+});
+
+test("quotedRuleAppearsInChunks rejects fabricated long quotes", () => {
+  const found = quotedRuleAppearsInChunks(
+    "the goalkeeper must remain perfectly still during the kick",
+    sampleChunks,
+  );
+  assert.equal(found, false);
+});
+
+function baseGoodResponse(): VerdictResponse {
+  return {
+    is_soccer_clip: true,
+    detected_incident_type: "offside",
+    original_referee_decision: "offside_called",
+    review_mode: "call_review",
+    verdict: "correct_call",
+    confidence: "high", // model self-rating; will be overwritten
+    key_moment_timestamp: "00:04",
+    what_happened: "Striker is past the second-last defender at the moment the ball is played.",
+    retrieval_source: "vertex",
+    rule_applied: {
+      law_number: "Law 11",
+      law_title: "Offside",
+      section: "Offside position",
+      retrieved_chunk_ids: ["law-11-offside-position"],
+      quoted_rule: "any part of the head, body or feet is nearer to the opponents' goal line than both the ball and the second-last opponent",
+    },
+    reasoning: ["s1", "s2", "s3"],
+    evidence_quality: {
+      camera_angle: "clear",
+      key_moment_visible: true,
+      ball_visible_when_needed: true,
+      players_visible_when_needed: true,
+      field_lines_visible_when_needed: true,
+      frame_rate_adequate: true,
+      required_context_missing: [],
+      issues: [],
+    },
+    review_limitations: [],
+  };
+}
+
+test("applyValidation: clean response derives high confidence", () => {
+  const res = applyValidation(baseGoodResponse(), {
+    retrievalSource: "vertex",
+    retrievedChunks: sampleChunks,
+    originalDecision: "offside_called",
+  });
+  assert.equal(res.response.confidence, "high");
+  assert.deepEqual(res.flags, []);
+});
+
+test("applyValidation: hallucinated chunk id downgrades confidence", () => {
+  const r = baseGoodResponse();
+  r.rule_applied!.retrieved_chunk_ids = ["fake-id"];
+  const res = applyValidation(r, {
+    retrievalSource: "vertex",
+    retrievedChunks: sampleChunks,
+    originalDecision: "offside_called",
+  });
+  assert.equal(res.response.confidence, "low");
+  assert.ok(res.flags.some((f) => f.startsWith("hallucinated-chunk-ids:fake-id")));
+});
+
+test("applyValidation: fabricated quoted_rule downgrades confidence", () => {
+  const r = baseGoodResponse();
+  r.rule_applied!.quoted_rule = "the goalkeeper must remain perfectly still during the kick";
+  const res = applyValidation(r, {
+    retrievalSource: "vertex",
+    retrievedChunks: sampleChunks,
+    originalDecision: "offside_called",
+  });
+  assert.equal(res.response.confidence, "low");
+  assert.ok(res.flags.includes("quoted-rule-not-in-retrieved-chunks"));
+});
+
+test("applyValidation: unknown decision forces inconclusive", () => {
+  const r = baseGoodResponse();
+  const res = applyValidation(r, {
+    retrievalSource: "vertex",
+    retrievedChunks: sampleChunks,
+    originalDecision: "unknown",
+  });
+  assert.equal(res.response.verdict, "inconclusive");
+  assert.equal(res.response.review_mode, "rule_assessment");
+  assert.ok(res.flags.some((f) => f.startsWith("override:unknown-decision-forced-inconclusive")));
+});
+
+test("applyValidation: retrieval_source=none enforces rule_applied=null", () => {
+  const r = baseGoodResponse();
+  const res = applyValidation(r, {
+    retrievalSource: "none",
+    retrievedChunks: [],
+    originalDecision: "offside_called",
+  });
+  assert.equal(res.response.rule_applied, null);
+  assert.ok(res.flags.includes("override:rule_applied-must-be-null-when-retrieval-source-is-none"));
+});
+
+test("applyValidation: retrieval_source authoritatively set from context", () => {
+  const r = baseGoodResponse();
+  r.retrieval_source = "vertex"; // model claimed vertex
+  const res = applyValidation(r, {
+    retrievalSource: "fallback", // but the function knows fallback fired
+    retrievedChunks: sampleChunks,
+    originalDecision: "offside_called",
+  });
+  assert.equal(res.response.retrieval_source, "fallback");
+});
+
+test("looksLikeVerdictResponse accepts valid shape", () => {
+  assert.equal(looksLikeVerdictResponse(baseGoodResponse()), true);
+});
+
+test("looksLikeVerdictResponse rejects missing fields", () => {
+  assert.equal(looksLikeVerdictResponse({ is_soccer_clip: true }), false);
+  assert.equal(looksLikeVerdictResponse(null), false);
+  assert.equal(looksLikeVerdictResponse("string"), false);
+});
+
+test("shortCircuitInconclusive sets retrieval_source to none and rule_applied to null", () => {
+  const r = shortCircuitInconclusive({
+    isSoccerClip: false,
+    detectedIncidentType: "unknown",
+    originalDecision: "penalty_awarded",
+    reason: "Clip does not appear to be soccer.",
+  });
+  assert.equal(r.retrieval_source, "none");
+  assert.equal(r.rule_applied, null);
+  assert.equal(r.verdict, "inconclusive");
+  assert.equal(r.is_soccer_clip, false);
+});

--- a/lib/validation.test.ts
+++ b/lib/validation.test.ts
@@ -1,5 +1,4 @@
-// Run with: node --test lib/**/*.test.ts
-// Node 24 strips types natively.
+// Run with: npm test
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,197 @@
+// PRD §11.7 response validation pipeline.
+// Pure functions — no AI calls, no I/O. Easy to unit-test.
+
+import { deriveConfidence, deriveReviewMode } from "./confidence.ts";
+import type {
+  Confidence,
+  OriginalRefereeDecision,
+  RetrievalSource,
+  Verdict,
+  VerdictResponse,
+} from "./types.ts";
+import type { RetrievedChunk } from "./retrieval/types.ts";
+
+export interface ValidationContext {
+  retrievalSource: RetrievalSource;
+  retrievedChunks: RetrievedChunk[];
+  originalDecision: OriginalRefereeDecision;
+}
+
+export interface ValidationOutcome {
+  response: VerdictResponse;
+  // Notes the validator flagged. Useful for the eval script and debug surfacing.
+  flags: string[];
+}
+
+// Step 1 of §11.7: parse model output, retry once with a stricter repair prompt
+// if needed. The repair prompt itself lives in lib/gemini/prompts.ts; this helper
+// only does the parse and signals whether a repair retry is warranted.
+export function tryParseModelJson(raw: string): { ok: true; value: unknown } | { ok: false; reason: string } {
+  // Models sometimes wrap JSON in ```json fences. Strip them defensively.
+  const stripped = raw.trim().replace(/^```(?:json)?\s*/, "").replace(/\s*```$/, "");
+  try {
+    return { ok: true, value: JSON.parse(stripped) };
+  } catch (e) {
+    return { ok: false, reason: (e as Error).message };
+  }
+}
+
+// Step 4 of §11.7: every retrieved_chunk_id must appear in the retrieval set.
+// If any id is invented, downgrade confidence to low and flag the response.
+export function validateChunkIds(
+  responseIds: string[] | undefined,
+  retrievedChunks: RetrievedChunk[],
+): { allKnown: boolean; unknownIds: string[] } {
+  if (!responseIds || responseIds.length === 0) {
+    return { allKnown: true, unknownIds: [] };
+  }
+  const known = new Set(retrievedChunks.map((c) => c.id));
+  const unknownIds = responseIds.filter((id) => !known.has(id));
+  return { allKnown: unknownIds.length === 0, unknownIds };
+}
+
+// Step 5 of §11.7: quoted_rule must appear verbatim (or as a clear substring)
+// within at least one retrieved chunk. We normalize whitespace because the
+// model often re-flows linebreaks.
+export function quotedRuleAppearsInChunks(quoted: string, chunks: RetrievedChunk[]): boolean {
+  if (!quoted) return false;
+  const norm = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
+  const needle = norm(quoted);
+  if (needle.length < 20) {
+    // Anything shorter than 20 normalized chars is too low-signal to count as
+    // a verbatim citation — could match coincidentally.
+    return false;
+  }
+  return chunks.some((c) => norm(c.text).includes(needle));
+}
+
+// Main validation entry point. Takes the parsed model JSON + the call's
+// retrieval context, and returns a final VerdictResponse plus any flags.
+//
+// Mutations performed (in order):
+//   1. retrieval_source overwritten to context.retrievalSource (model may not
+//      know which path fired).
+//   2. confidence overwritten via deriveConfidence (PRD §11.5).
+//   3. review_mode overwritten via deriveReviewMode (PRD §11.6).
+//   4. If original_referee_decision === "unknown" but verdict in {correct,bad},
+//      override verdict to "inconclusive" and set review_mode to "rule_assessment"
+//      (PRD §11.7 step 6 / §17 Q&A "What if the original call is unknown?").
+//   5. If validateChunkIds reports unknown ids OR quotedRuleAppearsInChunks is
+//      false, downgrade confidence to "low" and add flags.
+export function applyValidation(
+  parsed: VerdictResponse,
+  ctx: ValidationContext,
+): ValidationOutcome {
+  const flags: string[] = [];
+
+  // Start from a shallow copy so we don't mutate the caller's object.
+  const r: VerdictResponse = { ...parsed };
+
+  // (1) retrieval_source is set authoritatively by the analyze function.
+  r.retrieval_source = ctx.retrievalSource;
+
+  // (2) original_referee_decision should match what we sent in. Trust ctx.
+  r.original_referee_decision = ctx.originalDecision;
+
+  // (3) review_mode derivation.
+  r.review_mode = deriveReviewMode(ctx.originalDecision);
+
+  // (4) Unknown-decision override.
+  if (ctx.originalDecision === "unknown" && r.verdict !== "inconclusive") {
+    flags.push(`override:unknown-decision-forced-inconclusive (was ${r.verdict})`);
+    r.verdict = "inconclusive";
+    r.review_mode = "rule_assessment";
+  }
+
+  // (5) Citation grounding checks. Only meaningful when we actually retrieved
+  // chunks (i.e. retrieval_source !== "none"). When retrieval_source is "none",
+  // rule_applied should be null — enforce that here too.
+  let confidenceDowngrade = false;
+
+  if (ctx.retrievalSource === "none") {
+    if (r.rule_applied !== null) {
+      flags.push("override:rule_applied-must-be-null-when-retrieval-source-is-none");
+      r.rule_applied = null;
+    }
+  } else if (r.rule_applied !== null) {
+    const idCheck = validateChunkIds(r.rule_applied.retrieved_chunk_ids, ctx.retrievedChunks);
+    if (!idCheck.allKnown) {
+      flags.push(`hallucinated-chunk-ids:${idCheck.unknownIds.join(",")}`);
+      confidenceDowngrade = true;
+    }
+    if (!quotedRuleAppearsInChunks(r.rule_applied.quoted_rule, ctx.retrievedChunks)) {
+      flags.push("quoted-rule-not-in-retrieved-chunks");
+      confidenceDowngrade = true;
+    }
+  }
+
+  // (6) Confidence: derive from evidence_quality, then optionally downgrade.
+  const derived: Confidence = deriveConfidence(r.evidence_quality);
+  r.confidence = confidenceDowngrade ? "low" : derived;
+  if (confidenceDowngrade && derived !== "low") {
+    flags.push(`confidence-downgraded:${derived}->low`);
+  }
+
+  return { response: r, flags };
+}
+
+// Sentinels for callers that need to distinguish failure types.
+export type AnalyzeFailureKind = "unparseable" | "schema-mismatch";
+
+export interface AnalyzeFailure {
+  kind: AnalyzeFailureKind;
+  detail: string;
+  raw: string;
+}
+
+// Light schema check — does the parsed JSON have the top-level fields we need?
+// Full Zod-style validation is overkill; we just need to know whether the
+// model returned something close enough to apply business rules to.
+export function looksLikeVerdictResponse(value: unknown): value is VerdictResponse {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.is_soccer_clip === "boolean" &&
+    typeof v.detected_incident_type === "string" &&
+    typeof v.verdict === "string" &&
+    typeof v.what_happened === "string" &&
+    typeof v.evidence_quality === "object" &&
+    Array.isArray(v.reasoning) &&
+    (v.rule_applied === null || typeof v.rule_applied === "object")
+  );
+}
+
+// Convenience: the inconclusive shape used for short-circuit paths
+// (is_soccer_clip:false, incident_type:unsupported, etc.) per PRD §11.4.
+export function shortCircuitInconclusive(opts: {
+  isSoccerClip: boolean;
+  detectedIncidentType: VerdictResponse["detected_incident_type"];
+  originalDecision: OriginalRefereeDecision;
+  reason: string;
+  keyMomentTimestamp?: string;
+}): VerdictResponse {
+  return {
+    is_soccer_clip: opts.isSoccerClip,
+    detected_incident_type: opts.detectedIncidentType,
+    original_referee_decision: opts.originalDecision,
+    review_mode: deriveReviewMode(opts.originalDecision),
+    verdict: "inconclusive" satisfies Verdict,
+    confidence: "low",
+    key_moment_timestamp: opts.keyMomentTimestamp ?? "00:00",
+    what_happened: opts.reason,
+    retrieval_source: "none",
+    rule_applied: null,
+    reasoning: [opts.reason],
+    evidence_quality: {
+      camera_angle: "obstructed",
+      key_moment_visible: false,
+      ball_visible_when_needed: false,
+      players_visible_when_needed: false,
+      field_lines_visible_when_needed: false,
+      frame_rate_adequate: false,
+      required_context_missing: [],
+      issues: [opts.reason],
+    },
+    review_limitations: [opts.reason],
+  };
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -51,18 +51,34 @@ export function validateChunkIds(
 }
 
 // Step 5 of §11.7: quoted_rule must appear verbatim (or as a clear substring)
-// within at least one retrieved chunk. We normalize whitespace because the
-// model often re-flows linebreaks.
+// within at least one retrieved chunk. The normalizer handles:
+//   - whitespace re-flow (model often joins or splits lines)
+//   - Unicode NFKC compatibility (ligatures like ﬁ → fi, half-width forms)
+//   - smart quotes ("/"/'/' → "/'), em/en dashes (–/— → -)
+//   - soft hyphens (U+00AD) which PDF extraction often leaves embedded
+// Without these normalizations, valid IFAB quotes routed through the PDF →
+// embedding → model copy path get false-flagged as fabricated.
+export function normalizeForQuoteMatch(text: string): string {
+  return text
+    .normalize("NFKC")
+    .replace(/­/g, "")
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/[–—]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
 export function quotedRuleAppearsInChunks(quoted: string, chunks: RetrievedChunk[]): boolean {
   if (!quoted) return false;
-  const norm = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
-  const needle = norm(quoted);
+  const needle = normalizeForQuoteMatch(quoted);
   if (needle.length < 20) {
     // Anything shorter than 20 normalized chars is too low-signal to count as
     // a verbatim citation — could match coincidentally.
     return false;
   }
-  return chunks.some((c) => norm(c.text).includes(needle));
+  return chunks.some((c) => normalizeForQuoteMatch(c.text).includes(needle));
 }
 
 // Main validation entry point. Takes the parsed model JSON + the call's

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,8 +7,10 @@
 
 [functions]
   node_bundler = "esbuild"
-
-# Pin functions close to Vertex region to reduce retrieval round-trip.
-# Override via NETLIFY_FUNCTIONS_REGION env var when needed.
-[functions."analyze"]
-  included_files = ["data/law-to-file-id.json", "data/ifab-rules-fallback.json"]
+  # `included_files` at the global function scope applies to every generated
+  # function. The Next-on-Netlify plugin emits its own internal function name
+  # (e.g. `___netlify-server-handler`) rather than literal route names like
+  # "analyze", so per-function targeting by route name is unreliable.
+  # Globbing data/ here guarantees the JSON files ship into every function's
+  # bundle and are reachable via fs.readFileSync(join(process.cwd(), "data", ...)).
+  included_files = ["data/*.json"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.14",
+        "tsx": "^4.21.0",
         "typescript": "^5.6.3"
       },
       "engines": {
@@ -48,6 +49,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google/genai": {
@@ -1295,6 +1738,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1466,6 +1951,19 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob-parent": {
@@ -2240,6 +2738,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -2577,6 +3085,27 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test": "node --test \"lib/**/*.test.ts\"",
     "spike:gemini-video": "node scripts/spike/gemini-video.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "node --test \"lib/**/*.test.ts\"",
-    "spike:gemini-video": "node scripts/spike/gemini-video.ts"
+    "test": "tsx --test \"lib/**/*.test.ts\"",
+    "spike:gemini-video": "tsx scripts/spike/gemini-video.ts"
   },
   "dependencies": {
     "@google/genai": "^1.0.0",
@@ -25,6 +25,7 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.14",
+    "tsx": "^4.21.0",
     "typescript": "^5.6.3"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "jsx": "preserve",
     "incremental": true,
     "plugins": [{ "name": "next" }],


### PR DESCRIPTION
## Summary

Replaces the stub `/api/analyze` with the full PRD §11 two-pass pipeline: Cloudinary clip → Gemini File API → Pass 1 classification → deterministic incident-to-law mapping (§6) → retrieval scoped via `rag_file_ids` with Vertex→fallback failover → Pass 2 verdict → §11.7 validation pipeline.

**Status:** rebased onto `main` after PR #5 (real curated IFAB corpus) merged. PR #4's stub `data/ifab-rules-fallback.json` was dropped during the rebase; the curated corpus from PR #5 is the one in this PR's tree. The minimal `data/law-to-file-id.json` stub stays — it intentionally forces Vertex retrieval to throw "No Vertex file ID mapped for Law N" so the runtime falls through to the fallback path until corpus prep produces real Vertex file IDs.

## What's in

**Pipeline orchestrator** (`lib/analyze.ts`):
1. Upload Cloudinary clip to Gemini File API; reuse the handle across both passes (PRD §9). Capped at 25 MB via Content-Length guard + defensive byte-length check after buffer.
2. Pass 1 classification, skipped when `incidentType` is manual
3. Short-circuits for not-soccer / unsupported / unknown — return inconclusive with `retrieval_source: "none"`, `rule_applied: null` (PRD §11.4)
4. Deterministic incident → law mapping (PRD §6)
5. Retrieval via `lib/retrieval/index.ts`: tries Vertex (REST → `retrieveContexts` v1 with `vertex_rag_store.rag_resources[*].rag_file_ids` scoping, snake_case body verified vs the v1 docs); on any error logs and falls through to keyword-ranked fallback over `data/ifab-rules-fallback.json`
6. Pass 2 verdict with per-incident FPS via `videoMetadata` (PRD §9), one repair retry on JSON parse failure (PRD §11.7)
7. `applyValidation` runs all six §11.7 overrides

**Validation pipeline** (`lib/validation.ts` — pure, fully unit-tested):
- Hallucinated chunk-id detection
- `quoted_rule` substring check with **NFKC + smart-quote + em-dash + soft-hyphen** normalization (PDF→embedding→model copy paths frequently rewrite typography)
- ≥20-char minimum to avoid coincidental matches
- Unknown decision → forced `inconclusive` + `rule_assessment` review mode
- `confidence` overwritten via `deriveConfidence`; downgraded to `low` on any grounding failure
- `retrieval_source` and `original_referee_decision` set authoritatively from server context, never trusted from the model

**Vertex REST client** (`lib/retrieval/vertex.ts`): `POST {LOCATION}-aiplatform.googleapis.com/v1/{parent}:retrieveContexts` with snake_case body, `vertex_rag_store` as top-level sibling of `query` per the v1 docs. Uses `google-auth-library` for service-account auth (JSON inlined in `GOOGLE_APPLICATION_CREDENTIALS_JSON`).

**Fallback retrieval** (`lib/retrieval/fallback.ts`): keyword-ranked filter over the curated `data/ifab-rules-fallback.json` from PR #5. Tokenizes query (≥3 chars, stopword-filtered), counts term occurrences in `section + text`, sorts descending, document order on ties.

**Request validation** (`lib/request.ts`): hostname allow-list for `cloudinaryUrl` — accepts `res.cloudinary.com` / `cloudinary.com` and any subdomain via trailing-label match. Rejects look-alikes like `cloudinary.com.evil.com`. Without this guard, the route was a generic SSRF primitive.

## Toolchain

- `tsx` as the test runner so tests work on Node 20 (Netlify default), not just Node 24
- `npm test` → `tsx --test "lib/**/*.test.ts"`
- `allowImportingTsExtensions: true` + `.ts` extensions on relative imports (compatible with both tsx and Next.js bundler resolution)
- `netlify.toml` `included_files = ["data/*.json"]` at the global `[functions]` block (Next-on-Netlify generates internal handler names, not literal route names)

## Tests

**38/38 pass** with `npm test`. Coverage:
- `lib/validation.test.ts` — JSON parse + markdown-fence stripping; chunk-id membership; verbatim quote detection (whitespace, smart quotes, ligatures, soft hyphens, short-quote rejection, fabricated-quote rejection); `applyValidation` (clean response, hallucinated id, fabricated quote, unknown-decision override, retrieval_source=none enforcement, source authority); `looksLikeVerdictResponse`; `shortCircuitInconclusive`
- `lib/request.test.ts` — Cloudinary hostname allow/deny including the `cloudinary.com.evil.com` look-alike
- `lib/retrieval/fallback.test.ts` — keyword ranking, document-order fallback on empty query, k limit, unmatched-law empty result, **plus an integration test that clears the cache and proves all 8 supported laws load chunks with non-stub content from the real curated corpus on disk**

```
npm test          → 38/38 pass
npm run typecheck → clean
npm run build     → /api/analyze emitted as a dynamic route
```

## Out of scope

- Live end-to-end against real Gemini + Vertex creds (needs `GEMINI_API_KEY`, GCP project, ingested corpus → real `data/law-to-file-id.json`). Once those are in place, hit `POST /api/analyze` with `{cloudinaryUrl, originalDecision, incidentType}`.
- UI for upload/decision form — that's PR #6 (Hours 4 + 7)
- Verdict card UI (Hour 6)

## Test plan

- [x] `npm test` 38/38 pass (includes integration test against real curated corpus)
- [x] `npm run typecheck` clean
- [x] `npm run build` emits dynamic `/api/analyze` route
- [x] Real corpus loads end-to-end via `retrieveFromFallback`; integration test asserts non-stub content for all 8 laws
- [ ] Hit `POST /api/analyze` with bad JSON body → 400
- [ ] Missing `cloudinaryUrl` → 400; non-Cloudinary host → 400
- [ ] Unsupported `incident_type` → 200 with `verdict:"inconclusive"`, `retrieval_source:"none"`, `rule_applied:null`
- [ ] End-to-end with real Cloudinary URL + `incidentType: "foul"` → 200 with valid verdict, `retrieval_source: "fallback"` (since `law-to-file-id.json` is intentionally empty until corpus prep runs)
- [ ] Real Vertex path once `data/law-to-file-id.json` is populated by the prep script → `retrieval_source: "vertex"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)