### PR TITLE
Hours 4 + 7: Cloudinary upload + decision form + demo presets

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,5 @@
+import AnalyzeApp from "@/components/AnalyzeApp";
+
 export default function HomePage() {
-  return (
-    <main className="mx-auto max-w-3xl px-6 py-16">
-      <h1 className="text-4xl font-semibold tracking-tight">RefCheck AI</h1>
-      <p className="mt-4 text-lg text-neutral-500">
-        Rule-grounded second-review for soccer referee decisions. Upload a clip,
-        get an IFAB-cited verdict in under 30 seconds.
-      </p>
-      <p className="mt-8 rounded-lg border border-dashed border-neutral-300 p-6 text-sm text-neutral-500">
-        Upload UI lands in Hour 4. This page exists so the deploy target is
-        live before there is anything to deploy.
-      </p>
-    </main>
-  );
+  return <AnalyzeApp />;
 }

--- a/components/AnalyzeApp.tsx
+++ b/components/AnalyzeApp.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+// Single client component that owns the upload + form state for Hour 4
+// (Cloudinary upload, video preview) and Hour 7 (decision + incident form,
+// demo preset buttons). The verdict card UI is Hour 6 — this component
+// currently renders the API response as a JSON block.
+
+import { useState } from "react";
+import { CldUploadWidget } from "next-cloudinary";
+import { DEMO_PRESETS } from "@/lib/demoPresets";
+import {
+  ORIGINAL_DECISION_OPTIONS,
+  INCIDENT_TYPE_OPTIONS,
+} from "@/lib/formOptions";
+import type { IncidentType, OriginalRefereeDecision } from "@/lib/types";
+
+type AnalyzeStatus = "idle" | "submitting" | "succeeded" | "failed";
+
+const UPLOAD_PRESET = process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET ?? "";
+const CLOUD_NAME = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME ?? "";
+
+export default function AnalyzeApp() {
+  const [clipUrl, setClipUrl] = useState<string>("");
+  const [originalDecision, setOriginalDecision] =
+    useState<OriginalRefereeDecision>("foul_called");
+  const [incidentType, setIncidentType] = useState<IncidentType | "auto_detect">(
+    "auto_detect",
+  );
+  const [status, setStatus] = useState<AnalyzeStatus>("idle");
+  const [result, setResult] = useState<unknown>(null);
+  const [error, setError] = useState<string>("");
+
+  const cloudinaryConfigured = Boolean(UPLOAD_PRESET && CLOUD_NAME);
+
+  function loadPreset(presetId: string) {
+    const preset = DEMO_PRESETS.find((p) => p.id === presetId);
+    if (!preset) return;
+    setClipUrl(preset.cloudinaryUrl);
+    setOriginalDecision(preset.originalDecision);
+    setIncidentType(preset.incidentType);
+    setResult(null);
+    setError("");
+    setStatus("idle");
+  }
+
+  async function handleSubmit() {
+    if (!clipUrl) {
+      setError("Upload a clip or load a demo preset first.");
+      return;
+    }
+    setStatus("submitting");
+    setError("");
+    setResult(null);
+
+    try {
+      const resp = await fetch("/api/analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cloudinaryUrl: clipUrl,
+          originalDecision,
+          incidentType,
+        }),
+      });
+      const json = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        setStatus("failed");
+        setError(
+          (json as { error?: string }).error ??
+            `Analyze request failed (${resp.status})`,
+        );
+        return;
+      }
+      setResult(json);
+      setStatus("succeeded");
+    } catch (err) {
+      setStatus("failed");
+      setError((err as Error).message);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <header className="mb-10">
+        <h1 className="text-4xl font-semibold tracking-tight">RefCheck AI</h1>
+        <p className="mt-3 text-base text-neutral-500">
+          Rule-grounded second-review for soccer referee decisions. Upload a
+          clip, get an IFAB-cited verdict in under 30 seconds.
+        </p>
+      </header>
+
+      {/* Demo presets */}
+      <section className="mb-8">
+        <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-neutral-500">
+          Try a demo preset
+        </h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {DEMO_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              onClick={() => loadPreset(preset.id)}
+              className="rounded-lg border border-neutral-300 px-4 py-3 text-left text-sm hover:border-neutral-500 hover:bg-neutral-100 dark:border-neutral-700 dark:hover:border-neutral-500 dark:hover:bg-neutral-900"
+            >
+              <div className="font-medium">{preset.label}</div>
+              <div className="mt-1 text-xs text-neutral-500">
+                {preset.presenterNote}
+              </div>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* Upload */}
+      <section className="mb-6 rounded-xl border border-neutral-200 p-6 dark:border-neutral-800">
+        <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-neutral-500">
+          1. Upload a soccer clip
+        </h2>
+
+        {!cloudinaryConfigured ? (
+          <p className="rounded-md bg-amber-50 p-3 text-sm text-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
+            Cloudinary not configured. Set{" "}
+            <code className="rounded bg-amber-100 px-1 py-0.5 dark:bg-amber-900/40">
+              NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME
+            </code>{" "}
+            and{" "}
+            <code className="rounded bg-amber-100 px-1 py-0.5 dark:bg-amber-900/40">
+              NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET
+            </code>
+            . Demo presets still work without upload.
+          </p>
+        ) : (
+          <CldUploadWidget
+            uploadPreset={UPLOAD_PRESET}
+            options={{
+              sources: ["local"],
+              multiple: false,
+              resourceType: "video",
+              maxFileSize: 50 * 1024 * 1024,
+              clientAllowedFormats: ["mp4", "mov", "webm"],
+              folder: "refcheck-clips",
+            }}
+            onSuccess={(result) => {
+              if (
+                result?.info &&
+                typeof result.info === "object" &&
+                "secure_url" in result.info
+              ) {
+                const info = result.info as { secure_url?: string };
+                if (info.secure_url) setClipUrl(info.secure_url);
+              }
+            }}
+          >
+            {({ open }) => (
+              <button
+                type="button"
+                onClick={() => open()}
+                className="rounded-md bg-neutral-900 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-700 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300"
+              >
+                {clipUrl ? "Upload a different clip" : "Choose a clip"}
+              </button>
+            )}
+          </CldUploadWidget>
+        )}
+
+        {clipUrl ? (
+          <div className="mt-4">
+            <video
+              key={clipUrl}
+              src={clipUrl}
+              controls
+              className="w-full rounded-lg border border-neutral-200 dark:border-neutral-800"
+            />
+            <p className="mt-2 break-all text-xs text-neutral-500">
+              {clipUrl}
+            </p>
+          </div>
+        ) : null}
+      </section>
+
+      {/* Decision form */}
+      <section className="mb-6 rounded-xl border border-neutral-200 p-6 dark:border-neutral-800">
+        <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-neutral-500">
+          2. Tell us about the call
+        </h2>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">
+              Original referee decision
+            </span>
+            <select
+              value={originalDecision}
+              onChange={(e) =>
+                setOriginalDecision(e.target.value as OriginalRefereeDecision)
+              }
+              className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+            >
+              {ORIGINAL_DECISION_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Incident type</span>
+            <select
+              value={incidentType}
+              onChange={(e) =>
+                setIncidentType(
+                  e.target.value as IncidentType | "auto_detect",
+                )
+              }
+              className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+            >
+              {INCIDENT_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {originalDecision === "unknown" ? (
+          <p className="mt-3 rounded-md bg-blue-50 p-3 text-xs text-blue-900 dark:bg-blue-900/20 dark:text-blue-200">
+            Without the original decision, RefCheck switches to{" "}
+            <strong>rule assessment mode</strong> and won&apos;t say the call
+            was right or wrong — only what the rule says.
+          </p>
+        ) : null}
+      </section>
+
+      {/* Submit */}
+      <section className="mb-8">
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={status === "submitting" || !clipUrl}
+          className="w-full rounded-md bg-neutral-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-neutral-700 disabled:cursor-not-allowed disabled:bg-neutral-300 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300 dark:disabled:bg-neutral-700 dark:disabled:text-neutral-500"
+        >
+          {status === "submitting" ? "Analyzing…" : "Analyze clip"}
+        </button>
+        {error ? (
+          <p className="mt-3 rounded-md bg-red-50 p-3 text-sm text-red-900 dark:bg-red-900/20 dark:text-red-200">
+            {error}
+          </p>
+        ) : null}
+      </section>
+
+      {/* Result placeholder — verdict card UI is Hour 6 */}
+      {result ? (
+        <section className="rounded-xl border border-neutral-200 p-6 dark:border-neutral-800">
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-neutral-500">
+            Result
+          </h2>
+          <p className="mb-3 text-xs text-neutral-500">
+            Verdict card UI lands in Hour 6. Raw response below.
+          </p>
+          <pre className="overflow-x-auto rounded-md bg-neutral-100 p-4 text-xs dark:bg-neutral-900">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/lib/demoPresets.ts
+++ b/lib/demoPresets.ts
@@ -1,0 +1,57 @@
+// PRD §13 — three demo preset buttons. Each preset pre-fills original
+// decision + incident type and points at a Cloudinary clip already uploaded
+// to our cloud. URLs are placeholders until the team uploads real demo clips
+// (PRD §16 Hour 8). The `cloudinaryUrl` field uses res.cloudinary.com so the
+// SSRF guard in lib/request.ts accepts it.
+
+import type { IncidentType, OriginalRefereeDecision } from "./types.ts";
+
+export interface DemoPreset {
+  id: string;
+  label: string;
+  presenterNote: string;
+  cloudinaryUrl: string;
+  originalDecision: OriginalRefereeDecision;
+  incidentType: IncidentType | "auto_detect";
+  expectedLaw: string;
+  expectedVerdict: "correct_call" | "bad_call" | "inconclusive";
+}
+
+export const DEMO_PRESETS: DemoPreset[] = [
+  {
+    id: "foul-penalty",
+    label: "Foul / penalty",
+    presenterNote:
+      "Defender trips attacker inside the penalty area. Referee awarded a penalty.",
+    cloudinaryUrl:
+      "https://res.cloudinary.com/REPLACE_ME/video/upload/v1/refcheck-demo/foul-penalty.mp4",
+    originalDecision: "penalty_awarded",
+    incidentType: "foul",
+    expectedLaw: "Law 12",
+    expectedVerdict: "correct_call",
+  },
+  {
+    id: "offside-goal",
+    label: "Offside",
+    presenterNote:
+      "Striker is past the second-last defender at the moment the ball is played.",
+    cloudinaryUrl:
+      "https://res.cloudinary.com/REPLACE_ME/video/upload/v1/refcheck-demo/offside-goal.mp4",
+    originalDecision: "goal_allowed",
+    incidentType: "offside",
+    expectedLaw: "Law 11",
+    expectedVerdict: "bad_call",
+  },
+  {
+    id: "obstructed-inconclusive",
+    label: "Inconclusive",
+    presenterNote:
+      "Camera angle is obstructed at the moment of contact — evidence isn't sufficient.",
+    cloudinaryUrl:
+      "https://res.cloudinary.com/REPLACE_ME/video/upload/v1/refcheck-demo/obstructed.mp4",
+    originalDecision: "no_foul_called",
+    incidentType: "auto_detect",
+    expectedLaw: "Law 12",
+    expectedVerdict: "inconclusive",
+  },
+];

--- a/lib/formOptions.ts
+++ b/lib/formOptions.ts
@@ -1,0 +1,40 @@
+// Form option lists for the input UI. Mirror the enums in lib/types.ts and
+// lib/request.ts so the dropdowns offer exactly the values the API accepts.
+
+import type { IncidentType, OriginalRefereeDecision } from "./types.ts";
+
+export const ORIGINAL_DECISION_OPTIONS: Array<{
+  value: OriginalRefereeDecision;
+  label: string;
+}> = [
+  { value: "foul_called", label: "Foul called" },
+  { value: "no_foul_called", label: "No foul called" },
+  { value: "penalty_awarded", label: "Penalty awarded" },
+  { value: "no_penalty_awarded", label: "No penalty awarded" },
+  { value: "offside_called", label: "Offside called" },
+  { value: "goal_allowed", label: "Goal allowed" },
+  { value: "goal_disallowed", label: "Goal disallowed" },
+  { value: "throw_in_awarded", label: "Throw-in awarded" },
+  { value: "goal_kick_awarded", label: "Goal kick awarded" },
+  { value: "corner_kick_awarded", label: "Corner kick awarded" },
+  { value: "free_kick_awarded", label: "Free kick awarded" },
+  { value: "yellow_card_given", label: "Yellow card given" },
+  { value: "red_card_given", label: "Red card given" },
+  { value: "unknown", label: "Unknown" },
+];
+
+export const INCIDENT_TYPE_OPTIONS: Array<{
+  value: IncidentType | "auto_detect";
+  label: string;
+}> = [
+  { value: "auto_detect", label: "Auto-detect (recommended)" },
+  { value: "foul", label: "Foul or misconduct" },
+  { value: "handball", label: "Handball" },
+  { value: "offside", label: "Offside" },
+  { value: "penalty_kick", label: "Penalty kick" },
+  { value: "free_kick", label: "Free kick" },
+  { value: "throw_in", label: "Throw-in" },
+  { value: "goal_kick", label: "Goal kick" },
+  { value: "corner_kick", label: "Corner kick" },
+  { value: "ball_in_out", label: "Ball in / out of play" },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@google/genai": "^1.0.0",
         "google-auth-library": "^9.14.2",
         "next": "^15.1.0",
+        "next-cloudinary": "^6.17.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -38,6 +39,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cloudinary-util/types": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/types/-/types-1.5.10.tgz",
+      "integrity": "sha512-n5lrm7SdAXhgWEbkSJKHZGnaoO9G/g4WYS6HYnq/k4nLj79sYfQZOoKjyR8hF2iyLRdLkT+qlk68RNFFv5tKew==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary-util/url-loader": {
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/url-loader/-/url-loader-5.10.4.tgz",
+      "integrity": "sha512-gHkdvOaV+rlcwuIT7Vqd0ts/H5bsH4+bwFten/gIZ8oRjzdTBvgIY3R6F8bbJt0pFIEfpFEQLe4rPkl0NNqEWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary-util/types": "1.5.10",
+        "@cloudinary-util/util": "3.3.2",
+        "@cloudinary/url-gen": "1.15.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@cloudinary-util/url-loader/node_modules/@cloudinary-util/util": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/util/-/util-3.3.2.tgz",
+      "integrity": "sha512-Cc0iFxzfl7fcOXuznpeZFGYC885Of/vDgccRDnhTe/8Rf8YKv2PjLtezyo0VgmdA/CpeZy29NCXAsf6liokbwg==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary-util/util": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/util/-/util-4.0.0.tgz",
+      "integrity": "sha512-S4xcou/3A7l5o+bcKlw2VHBNgwups7/0lbVDT/cO5YmtrcEYXgj6LGmwnjvpTm/x571VPVN8x5jWdT3rLZiKJQ==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary/transformation-builder-sdk": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary/transformation-builder-sdk/-/transformation-builder-sdk-1.21.2.tgz",
+      "integrity": "sha512-ehOgKUaP+Nvuf7B0TosmB8iilL0kdiVjzjl8tIK06cjvsNnwSJI3xP9nEJmKkvqNxwwFwvYXT+mxUTqnSv9JOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/url-gen": "^1.7.0"
+      }
+    },
+    "node_modules/@cloudinary/url-gen": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudinary/url-gen/-/url-gen-1.15.0.tgz",
+      "integrity": "sha512-bjU67eZxLUgoRy/Plli4TQio7q6P31OYqnEgXxeN9TKXrzr6h0DeEdIUhKI9gy3HkEBWXWWJIPh7j7gkOJPnyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/transformation-builder-sdk": "^1.10.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1799,6 +1848,21 @@
         }
       }
     },
+    "node_modules/next-cloudinary": {
+      "version": "6.17.5",
+      "resolved": "https://registry.npmjs.org/next-cloudinary/-/next-cloudinary-6.17.5.tgz",
+      "integrity": "sha512-YIyIWw5Ds30f4rnED+E9ssLUd94FOPTtbkO2KUvOcw9z4irOEIpb1goxMxbn2EUBnIGQOd6uUf1gFizjME7pMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary-util/types": "1.5.10",
+        "@cloudinary-util/url-loader": "5.10.4",
+        "@cloudinary-util/util": "4.0.0"
+      },
+      "peerDependencies": {
+        "next": "^12 || ^13 || ^14 || >=15.0.0-rc || ^15",
+        "react": "^17 || ^18 || >=19.0.0-beta || ^19"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -2694,6 +2758,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@google/genai": "^1.0.0",
     "google-auth-library": "^9.14.2",
     "next": "^15.1.0",
+    "next-cloudinary": "^6.17.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## Summary

Implements the full input UI for `/api/analyze`. Pairs Hour 4 (upload) with the form-and-presets parts of Hour 7 since they share the same client component and state. The verdict card (Hour 6) is **not** in this PR — the result block currently renders raw JSON.

## What's in

**Cloudinary upload** (Hour 4):
- `next-cloudinary`'s `<CldUploadWidget>` scoped to mp4/mov/webm under 50 MB, folder `refcheck-clips`
- Inline `<video>` preview after upload
- Friendly "Cloudinary not configured" banner when `NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME` / `NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET` are missing — demo presets still work in that state

**Form + presets** (Hour 7):
- Original referee decision dropdown (14 options per PRD §7)
- Incident type selector with auto-detect default (10 options per §7)
- 3 demo preset buttons (foul/penalty, offside, inconclusive) per §13. URLs use `res.cloudinary.com/REPLACE_ME/...` placeholders until real demo clips are uploaded at Hour 8 — they pass the SSRF guard in `lib/request.ts` because the hostname ends with `.cloudinary.com`
- Unknown-decision notice explaining `rule_assessment` mode (§7)
- Submit button disabled until a clip is selected; spinner state during the call; surfaces server errors

**Wiring:**
- `app/page.tsx` is now a thin server component that renders `<AnalyzeApp />`
- `components/AnalyzeApp.tsx` is the single client component owning all upload/form/result state
- Form payload matches what `parseAnalyzeRequest` expects on PR #4

## Out of scope

- **Verdict card UI** (Hour 6) — the result block currently shows raw JSON; the structured card lands next
- **shadcn/ui components** — using plain Tailwind for now to keep this PR focused; can layer shadcn later if there's time
- **Real demo clip Cloudinary URLs** — placeholders until Hour 8

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean (home bundle 46.8 kB, +30 kB for the upload widget)
- [x] Dev server returns 200 on `/`; rendered HTML contains every section (RefCheck AI title, demo presets row, original decision, incident type, Cloudinary banner)
- [x] `POST /api/analyze` with the form payload round-trips through this branch's stub (returns echo JSON). Once PR #4 lands and merges, this submits to the real pipeline.
- [ ] Click each demo preset → form fields populate and the placeholder Cloudinary URL appears in state (visible test once a real clip is uploaded for one preset)
- [ ] Real Cloudinary upload (needs env vars set) → secure_url comes back, preview plays
- [ ] Submit with `originalDecision: "unknown"` → blue notice appears, payload still sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)