### PR TITLE
Addressed issue 8

### DIFF
--- a/scripts/python/law-page-ranges.json
+++ b/scripts/python/law-page-ranges.json
@@ -1,11 +1,11 @@
 {
   "_comment": "1-indexed inclusive page ranges in the IFAB Laws of the Game PDF. Open the PDF, find each law's first and last page, fill in below. The IFAB PDF table-of-contents lists each law's start page; the end page is the page before the next law (or the appendix).",
-  "Law 9": [0, 0],
-  "Law 11": [0, 0],
-  "Law 12": [0, 0],
-  "Law 13": [0, 0],
-  "Law 14": [0, 0],
-  "Law 15": [0, 0],
-  "Law 16": [0, 0],
-  "Law 17": [0, 0]
+  "Law 9": [95, 96],
+  "Law 11": [103, 108],
+  "Law 12": [109, 124],
+  "Law 13": [125, 128],
+  "Law 14": [129, 134],
+  "Law 15": [135, 138],
+  "Law 16": [139, 142],
+  "Law 17": [143, 145]
 }


### PR DESCRIPTION
scripts/python/law-page-ranges.json exists with all 8 laws populated (no zeros remaining)
and
Verified by running python scripts/python/prep_corpus.py split --pdf <path> --ranges-json scripts/python/law-page-ranges.json produces 8 PDFs in data/per-law-pdfs/


Output made 8 PDFs, and they look accurate to what they are