### PR TITLE
addressed issue 12

### DIFF
--- a/components/VerdictCard.tsx
+++ b/components/VerdictCard.tsx
@@ -7,6 +7,7 @@ import type {
   Confidence,
   EvidenceQuality,
   RetrievalSource,
+  ReviewMode,
   Verdict,
   VerdictResponse,
 } from "@/lib/types";
@@ -39,7 +40,18 @@ const RETRIEVAL_BADGE_COPY: Partial<Record<RetrievalSource, string>> = {
 export default function VerdictCard({ response }: { response: VerdictResponse }) {
   return (
     <section className="space-y-6 rounded-xl border border-neutral-200 p-6 dark:border-neutral-800">
-      <Header verdict={response.verdict} confidence={response.confidence} />
+      {response.review_mode === "rule_assessment" ? (
+        <Note>
+          Original referee decision was not provided, so RefCheck is in rule
+          assessment mode. It explains what the rule says without saying
+          whether the referee was right or wrong.
+        </Note>
+      ) : null}
+      <Header
+        verdict={response.verdict}
+        confidence={response.confidence}
+        reviewMode={response.review_mode}
+      />
 
       <Summary
         whatHappened={response.what_happened}
@@ -63,16 +75,23 @@ export default function VerdictCard({ response }: { response: VerdictResponse })
 function Header({
   verdict,
   confidence,
+  reviewMode,
 }: {
   verdict: Verdict;
   confidence: Confidence;
+  reviewMode: ReviewMode;
 }) {
+  const badgeText =
+    reviewMode === "rule_assessment"
+      ? "Rule assessment"
+      : VERDICT_COPY[verdict];
+
   return (
     <div className="flex flex-wrap items-center gap-3">
       <span
         className={`inline-flex items-center rounded-full px-4 py-1.5 text-sm font-semibold uppercase tracking-wide text-white ${VERDICT_BG[verdict]}`}
       >
-        {VERDICT_COPY[verdict]}
+        {badgeText}
       </span>
       <span className="inline-flex items-center rounded-full border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-700 dark:border-neutral-700 dark:text-neutral-300">
         Confidence: {confidence}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,7 +1403,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1586,7 +1585,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2173,7 +2171,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2545,7 +2542,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2739,7 +2735,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2749,7 +2744,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3110,7 +3104,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3156,7 +3149,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"


### PR DESCRIPTION
✅ Fix implemented
Updated [VerdictCard.tsx]
Added a blue/info-style notice at the top of the card when [response.review_mode === "rule_assessment"]

Changed the verdict badge label to "Rule assessment" in that mode
Kept the existing call_review behavior unchanged
Avoided right/wrong judgment language inside the verdict card itself

🔧 Validation
Installed local dependencies with npm install
Successfully ran npm run typecheck


Check for completion