### PR TITLE
Addressed issue 14

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,5 @@ CLOUDINARY_API_SECRET=
 # Netlify
 # NETLIFY_FUNCTIONS_REGION=us-east-1
 # When "1", deployed URL renders demo presets without ?demo=1
-DEMO_MODE_DEFAULT=
+# Must be prefixed with NEXT_PUBLIC_ to be visible in the browser.
+NEXT_PUBLIC_DEMO_MODE_DEFAULT=

--- a/components/AnalyzeApp.tsx
+++ b/components/AnalyzeApp.tsx
@@ -3,7 +3,7 @@
 // Single client component that owns the upload + form state and renders the
 // VerdictCard once /api/analyze returns.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CldUploadWidget } from "next-cloudinary";
 import { DEMO_PRESETS } from "@/lib/demoPresets";
 import {
@@ -21,6 +21,11 @@ type AnalyzeStatus = "idle" | "submitting" | "succeeded" | "failed";
 
 const UPLOAD_PRESET = process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET ?? "";
 const CLOUD_NAME = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME ?? "";
+const DEMO_MODE_DEFAULT = process.env.NEXT_PUBLIC_DEMO_MODE_DEFAULT === "1";
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export default function AnalyzeApp() {
   const [clipUrl, setClipUrl] = useState<string>("");
@@ -32,8 +37,18 @@ export default function AnalyzeApp() {
   const [status, setStatus] = useState<AnalyzeStatus>("idle");
   const [result, setResult] = useState<VerdictResponse | null>(null);
   const [error, setError] = useState<string>("");
+  const [isDemoModeQuery, setIsDemoModeQuery] = useState(false);
+  const [selectedDemoPresetId, setSelectedDemoPresetId] = useState<string | null>(null);
+  const [isDemoResponse, setIsDemoResponse] = useState(false);
 
   const cloudinaryConfigured = Boolean(UPLOAD_PRESET && CLOUD_NAME);
+  const isDemoMode = isDemoModeQuery || DEMO_MODE_DEFAULT;
+
+  useEffect(() => {
+    setIsDemoModeQuery(
+      new URLSearchParams(window.location.search).get("demo") === "1",
+    );
+  }, []);
 
   function loadPreset(presetId: string) {
     const preset = DEMO_PRESETS.find((p) => p.id === presetId);
@@ -41,6 +56,7 @@ export default function AnalyzeApp() {
     setClipUrl(preset.cloudinaryUrl);
     setOriginalDecision(preset.originalDecision);
     setIncidentType(preset.incidentType);
+    setSelectedDemoPresetId(preset.id);
     setResult(null);
     setError("");
     setStatus("idle");
@@ -51,9 +67,33 @@ export default function AnalyzeApp() {
       setError("Upload a clip or load a demo preset first.");
       return;
     }
+
     setStatus("submitting");
     setError("");
     setResult(null);
+    setIsDemoResponse(false);
+
+    if (isDemoMode && selectedDemoPresetId) {
+      try {
+        const resp = await fetch(`/demo-responses/${selectedDemoPresetId}.json`);
+        if (!resp.ok) {
+          setStatus("failed");
+          setError(`Demo response not found (${resp.status})`);
+          return;
+        }
+
+        const json = (await resp.json()) as VerdictResponse;
+        await sleep(1500);
+        setResult(json);
+        setStatus("succeeded");
+        setIsDemoResponse(true);
+        return;
+      } catch (err) {
+        setStatus("failed");
+        setError((err as Error).message);
+        return;
+      }
+    }
 
     try {
       const resp = await fetch("/api/analyze", {
@@ -76,6 +116,7 @@ export default function AnalyzeApp() {
       }
       setResult(json as VerdictResponse);
       setStatus("succeeded");
+      setIsDemoResponse(false);
     } catch (err) {
       setStatus("failed");
       setError((err as Error).message);
@@ -149,7 +190,10 @@ export default function AnalyzeApp() {
                 "secure_url" in result.info
               ) {
                 const info = result.info as { secure_url?: string };
-                if (info.secure_url) setClipUrl(info.secure_url);
+                if (info.secure_url) {
+                  setClipUrl(info.secure_url);
+                  setSelectedDemoPresetId(null);
+                }
               }
             }}
           >
@@ -252,7 +296,16 @@ export default function AnalyzeApp() {
         ) : null}
       </section>
 
-      {result ? <VerdictCard response={result} /> : null}
+      {result ? (
+        <>
+          {isDemoResponse ? (
+            <div className="mb-4 inline-flex rounded-full border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:border-amber-500/40 dark:bg-amber-900/20 dark:text-amber-200">
+              Demo mode (cached)
+            </div>
+          ) : null}
+          <VerdictCard response={result} />
+        </>
+      ) : null}
     </main>
   );
 }

--- a/components/AnalyzeApp.tsx
+++ b/components/AnalyzeApp.tsx
@@ -57,6 +57,7 @@ export default function AnalyzeApp() {
     setOriginalDecision(preset.originalDecision);
     setIncidentType(preset.incidentType);
     setSelectedDemoPresetId(preset.id);
+    setIsDemoResponse(false);
     setResult(null);
     setError("");
     setStatus("idle");
@@ -237,9 +238,10 @@ export default function AnalyzeApp() {
             </span>
             <select
               value={originalDecision}
-              onChange={(e) =>
-                setOriginalDecision(e.target.value as OriginalRefereeDecision)
-              }
+              onChange={(e) => {
+                setOriginalDecision(e.target.value as OriginalRefereeDecision);
+                setSelectedDemoPresetId(null);
+              }}
               className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
             >
               {ORIGINAL_DECISION_OPTIONS.map((opt) => (
@@ -254,11 +256,12 @@ export default function AnalyzeApp() {
             <span className="mb-1 block font-medium">Incident type</span>
             <select
               value={incidentType}
-              onChange={(e) =>
+              onChange={(e) => {
                 setIncidentType(
                   e.target.value as IncidentType | "auto_detect",
-                )
-              }
+                );
+                setSelectedDemoPresetId(null);
+              }}
               className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
             >
               {INCIDENT_TYPE_OPTIONS.map((opt) => (

--- a/lib/demoResponseGrounding.test.ts
+++ b/lib/demoResponseGrounding.test.ts
@@ -1,0 +1,62 @@
+// Run with: npm test
+//
+// Cached demo responses in public/demo-responses/*.json bypass the live
+// validation pipeline (AnalyzeApp short-circuits to the static JSON when a
+// preset is loaded in demo mode). This fixture test re-applies the §11.7
+// citation-grounding checks to those static fixtures so they cannot regress
+// into ungrounded chunk ids or fabricated rule quotes — i.e. the demo cannot
+// show a citation badge that would never have passed production validation.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { validateChunkIds, quotedRuleAppearsInChunks } from "./validation.ts";
+import { DEMO_PRESETS } from "./demoPresets.ts";
+import type { RetrievedChunk } from "./retrieval/types.ts";
+import type { VerdictResponse } from "./types.ts";
+
+const corpus = JSON.parse(
+  readFileSync(resolve("data/ifab-rules-fallback.json"), "utf8"),
+) as RetrievedChunk[];
+
+function loadDemoResponse(presetId: string): VerdictResponse {
+  const path = resolve("public/demo-responses", `${presetId}.json`);
+  return JSON.parse(readFileSync(path, "utf8")) as VerdictResponse;
+}
+
+for (const preset of DEMO_PRESETS) {
+  test(`demo response "${preset.id}" cites real corpus chunks`, () => {
+    const resp = loadDemoResponse(preset.id);
+
+    if (resp.rule_applied === null) {
+      // Mirrors the validator invariant in lib/validation.ts:127-131:
+      // when there is no rule citation, retrieval_source must be "none".
+      assert.equal(
+        resp.retrieval_source,
+        "none",
+        `${preset.id}: rule_applied is null but retrieval_source is "${resp.retrieval_source}" — must be "none"`,
+      );
+      return;
+    }
+
+    const idCheck = validateChunkIds(
+      resp.rule_applied.retrieved_chunk_ids,
+      corpus,
+    );
+    assert.ok(
+      idCheck.allKnown,
+      `${preset.id}: hallucinated chunk ids ${idCheck.unknownIds.join(",")}`,
+    );
+
+    // Quote-matching only sees the chunks the response actually cites — same
+    // as production, where the prompt only gives the model the retrieved set.
+    const cited = corpus.filter((c) =>
+      resp.rule_applied!.retrieved_chunk_ids.includes(c.id),
+    );
+    assert.ok(
+      quotedRuleAppearsInChunks(resp.rule_applied.quoted_rule, cited),
+      `${preset.id}: quoted_rule is not a verbatim substring of any cited chunk`,
+    );
+  });
+}

--- a/public/demo-responses/foul-penalty.json
+++ b/public/demo-responses/foul-penalty.json
@@ -13,7 +13,7 @@
     "law_title": "Fouls and Misconduct",
     "section": "Direct free kick",
     "retrieved_chunk_ids": ["law-12-direct-free-kick-careless-reckless-excessive"],
-    "quoted_rule": "A direct free kick is awarded if a player commits any of the following offences against an opponent in a manner considered by the referee to be careless, reckless or using excessive force: charges, jumps at, kicks or attempts to kick, pushes, strikes or attempts to strike, tackles or challenges, trips or attempts to trip"
+    "quoted_rule": "A direct free kick is awarded if a player commits any of the following offences against an opponent in a manner considered by the referee to be careless, reckless or using excessive force: • charges • jumps at • kicks or attempts to kick • pushes • strikes or attempts to strike (including head-butt) • tackles or challenges • trips or attempts to trip"
   },
   "reasoning": [
     "The clip shows a tackle attempt by a defender against an attacking player inside the penalty area.",

--- a/public/demo-responses/obstructed-inconclusive.json
+++ b/public/demo-responses/obstructed-inconclusive.json
@@ -13,7 +13,7 @@
     "law_title": "Fouls and Misconduct",
     "section": "Direct free kick",
     "retrieved_chunk_ids": ["law-12-direct-free-kick-careless-reckless-excessive"],
-    "quoted_rule": "A direct free kick is awarded if a player commits any of the following offences against an opponent in a manner considered by the referee to be careless, reckless or using excessive force: charges, jumps at, kicks or attempts to kick, pushes, strikes or attempts to strike, tackles or challenges, trips or attempts to trip"
+    "quoted_rule": "A direct free kick is awarded if a player commits any of the following offences against an opponent in a manner considered by the referee to be careless, reckless or using excessive force: • charges • jumps at • kicks or attempts to kick • pushes • strikes or attempts to strike (including head-butt) • tackles or challenges • trips or attempts to trip"
   },
   "reasoning": [
     "The clip shows a 50-50 challenge between two players in midfield.",

--- a/public/demo-responses/offside-goal.json
+++ b/public/demo-responses/offside-goal.json
@@ -13,7 +13,7 @@
     "law_title": "Offside",
     "section": "Offside position",
     "retrieved_chunk_ids": ["law-11-offside-position-definition", "law-11-offside-offence-interfering"],
-    "quoted_rule": "A player is in an offside position if any part of the head, body or feet is in the opponents' half (excluding the halfway line) and any part of the head, body or feet is nearer to the opponents' goal line than both the ball and the second-last opponent"
+    "quoted_rule": "A player is in an offside position if: • any part of the head, body or feet is in the opponents’ half ( excluding the halfway line ) and • any part of the head, body or feet is nearer to the opponents’ goal line than both the ball and the second-last opponent"
   },
   "reasoning": [
     "The clip shows an attacker timing a run onto a through ball and scoring.",


### PR DESCRIPTION
✅ Demo mode support added
What changed
Updated [AnalyzeApp.tsx](vscode-file://vscode-app/c:/Users/carde/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Detects ?demo=1 from [window.location.search]
Honors [process.env.NEXT_PUBLIC_DEMO_MODE_DEFAULT === "1"]
Uses cached JSON from [/demo-responses/{presetId}.json] only when a demo preset has been loaded
Simulates a 1.5s delay before showing cached results
Clears demo-preset cached mode when the user uploads a manual clip
Shows a small Demo mode (cached) badge above the verdict card when a cached response is used
Updated [.env.example]

Replaced [DEMO_MODE_DEFAULT] with [NEXT_PUBLIC_DEMO_MODE_DEFAULT]
Added comment noting client visibility requirement
Validation
npm run typecheck passed cleanly
Note
I did not add actual [public/demo-responses/{presetId}.json] files in this patch; the code now expects those static assets to be available for cached demo mode to work end-to-end.