### PR TITLE
Add CI workflow: typecheck + test + build on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# A PR with the same head ref shouldn't pile up jobs — cancel the older run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: typecheck · test · build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        # next build runs lint + the same TS checks our typecheck step does, plus
+        # produces a deployable artifact. Env vars below are placeholders so the
+        # build doesn't bail on missing secrets — the Netlify deploy uses real
+        # values via dashboard env.
+        env:
+          NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME: ci-placeholder
+          NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET: ci-placeholder
+        run: npm run build


### PR DESCRIPTION
Closes #18.

## Summary

Single `ubuntu-latest` job triggered on PRs and pushes to `main`. Steps:
1. `npm ci` (with the npm cache)
2. `npm run typecheck`
3. `npm test`
4. `npm run build` (with placeholder Cloudinary env vars so the build doesn't bail; real values come from Netlify on deploy)

Concurrency group cancels superseded runs on the same ref — keeps PR queue tidy when force-pushing.

## Test plan

- [ ] First run will execute on this PR — verify all steps green
- [x] Steps mirror what works locally (typecheck, test, build all clean on this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)