### PR TITLE
Cached demo responses for the three demo presets

### DIFF
--- a/public/demo-responses/foul-penalty.json
+++ b/public/demo-responses/foul-penalty.json
@@ -1,0 +1,36 @@
+{
+  "is_soccer_clip": true,
+  "detected_incident_type": "foul",
+  "original_referee_decision": "penalty_awarded",
+  "review_mode": "call_review",
+  "verdict": "correct_call",
+  "confidence": "high",
+  "key_moment_timestamp": "0:04",
+  "what_happened": "A defender extends a leg into the path of a forward inside the penalty area, making leg-to-leg contact before any contact with the ball.",
+  "retrieval_source": "fallback",
+  "rule_applied": {
+    "law_number": "Law 12",
+    "law_title": "Fouls and Misconduct",
+    "section": "Direct free kick",
+    "retrieved_chunk_ids": ["law-12-direct-free-kick-careless-reckless-excessive"],
+    "quoted_rule": "A direct free kick is awarded if a player commits any of the following offences against an opponent in a manner considered by the referee to be careless, reckless or using excessive force: charges, jumps at, kicks or attempts to kick, pushes, strikes or attempts to strike, tackles or challenges, trips or attempts to trip"
+  },
+  "reasoning": [
+    "The clip shows a tackle attempt by a defender against an attacking player inside the penalty area.",
+    "Law 12 lists trips and challenges committed carelessly or recklessly as direct-free-kick offences; in the penalty area this becomes a penalty.",
+    "Visible evidence: the defender's leading foot makes contact with the attacker's planted leg before any contact with the ball.",
+    "Comparing the visible contact to the rule, the challenge meets the careless threshold for a direct free kick.",
+    "The original decision (penalty awarded) is consistent with what the rule prescribes for this offence inside the penalty area."
+  ],
+  "evidence_quality": {
+    "camera_angle": "clear",
+    "key_moment_visible": true,
+    "ball_visible_when_needed": true,
+    "players_visible_when_needed": true,
+    "field_lines_visible_when_needed": true,
+    "frame_rate_adequate": true,
+    "required_context_missing": [],
+    "issues": []
+  },
+  "review_limitations": []
+}

--- a/public/demo-responses/obstructed-inconclusive.json
+++ b/public/demo-responses/obstructed-inconclusive.json
@@ -1,0 +1,45 @@
+{
+  "is_soccer_clip": true,
+  "detected_incident_type": "foul",
+  "original_referee_decision": "no_foul_called",
+  "review_mode": "call_review",
+  "verdict": "inconclusive",
+  "confidence": "low",
+  "key_moment_timestamp": "0:02",
+  "what_happened": "Two players converge on a loose ball in midfield; another player crosses the foreground and obstructs the camera at the moment of contact.",
+  "retrieval_source": "fallback",
+  "rule_applied": {
+    "law_number": "Law 12",
+    "law_title": "Fouls and Misconduct",
+    "section": "Direct free kick",
+    "retrieved_chunk_ids": ["law-12-direct-free-kick-careless-reckless-excessive"],
+    "quoted_rule": "A direct free kick is awarded if a player commits any of the following offences against an opponent in a manner considered by the referee to be careless, reckless or using excessive force: charges, jumps at, kicks or attempts to kick, pushes, strikes or attempts to strike, tackles or challenges, trips or attempts to trip"
+  },
+  "reasoning": [
+    "The clip shows a 50-50 challenge between two players in midfield.",
+    "Law 12 turns on whether the challenge was careless, reckless, or used excessive force — that judgment requires seeing the contact itself.",
+    "Visible evidence: a third player crosses the camera line at the exact frame of contact, blocking view of the challenge.",
+    "Without seeing the contact, the rule cannot be applied with confidence — careless vs. fair is not determinable from this angle.",
+    "The original decision (no foul called) cannot be evaluated against the rule because the determining evidence is not visible."
+  ],
+  "evidence_quality": {
+    "camera_angle": "obstructed",
+    "key_moment_visible": false,
+    "ball_visible_when_needed": false,
+    "players_visible_when_needed": false,
+    "field_lines_visible_when_needed": true,
+    "frame_rate_adequate": true,
+    "required_context_missing": [
+      "Player position at the exact moment of contact",
+      "Whether the defender played the ball before the attacker"
+    ],
+    "issues": [
+      "A third player crosses the foreground and obscures the contact moment.",
+      "No alternate angle or replay is provided in the clip."
+    ]
+  },
+  "review_limitations": [
+    "The clip does not show the moment of contact clearly enough to judge fairness of the challenge.",
+    "A second camera angle or slow-motion replay would likely resolve this clip — the live single angle is insufficient."
+  ]
+}

--- a/public/demo-responses/offside-goal.json
+++ b/public/demo-responses/offside-goal.json
@@ -1,0 +1,40 @@
+{
+  "is_soccer_clip": true,
+  "detected_incident_type": "offside",
+  "original_referee_decision": "goal_allowed",
+  "review_mode": "call_review",
+  "verdict": "bad_call",
+  "confidence": "medium",
+  "key_moment_timestamp": "0:03",
+  "what_happened": "An attacker receives a through ball and finishes; at the moment the ball is played by the team-mate, the attacker's torso is past the second-last defender.",
+  "retrieval_source": "fallback",
+  "rule_applied": {
+    "law_number": "Law 11",
+    "law_title": "Offside",
+    "section": "Offside position",
+    "retrieved_chunk_ids": ["law-11-offside-position-definition", "law-11-offside-offence-interfering"],
+    "quoted_rule": "A player is in an offside position if any part of the head, body or feet is in the opponents' half (excluding the halfway line) and any part of the head, body or feet is nearer to the opponents' goal line than both the ball and the second-last opponent"
+  },
+  "reasoning": [
+    "The clip shows an attacker timing a run onto a through ball and scoring.",
+    "Law 11 places a player in an offside position when their torso is nearer the opponent's goal line than the second-last defender at the moment the ball is played by a team-mate.",
+    "Visible evidence: at the frame of the team-mate's pass, the attacker's body is clearly past the last defender's line.",
+    "Because the attacker subsequently played the ball, this constitutes interfering with play and is therefore an offside offence.",
+    "The original decision (goal allowed) does not match what the rule prescribes; the goal should have been disallowed for offside."
+  ],
+  "evidence_quality": {
+    "camera_angle": "partial",
+    "key_moment_visible": true,
+    "ball_visible_when_needed": true,
+    "players_visible_when_needed": true,
+    "field_lines_visible_when_needed": true,
+    "frame_rate_adequate": true,
+    "required_context_missing": [],
+    "issues": [
+      "Camera is on the attacking half but slightly off-axis from the offside line, so the offset is judged from torso position rather than a perfectly perpendicular reference."
+    ]
+  },
+  "review_limitations": [
+    "Without a true offside-line camera angle, certainty is medium rather than high — the offset is visible but not measurable in pixels."
+  ]
+}


### PR DESCRIPTION
Closes #13. Pairs with PR #22 (the ?demo=1 toggle).

## Summary

Three JSON files at \`public/demo-responses/{presetId}.json\` — one per demo preset in \`lib/demoPresets.ts\` (\`foul-penalty\`, \`offside-goal\`, \`obstructed-inconclusive\`). Each is a complete \`VerdictResponse\` matching \`lib/types.ts\` §11.4:

- **foul-penalty.json** — Law 12 careless-trip rule, verdict \`correct_call\`, high confidence, clean evidence quality.
- **offside-goal.json** — Law 11 offside-position rule, verdict \`bad_call\`, medium confidence (camera angle off-axis), one issue noted.
- **obstructed-inconclusive.json** — Law 12 careless-tackle rule, verdict \`inconclusive\`, low confidence, obstructed camera angle, two missing-context items, two limitations. Demonstrates the brief-endorsed "Inconclusive" path.

Quoted rules pulled verbatim from \`data/ifab-rules-fallback.json\` so the validation pipeline (\`lib/validation.ts\` quoted_rule check) would pass on these payloads.

## Why these are placeholders

Until issue #7 uploads real demo clips, these are hand-written. Once #7 is done, the team should re-run \`/api/analyze\` against each clip and overwrite these files with the live responses. Architecture is the same either way — the toggle in #22 reads from disk.

## Test plan

- [x] All three files are valid JSON
- [x] Schema matches \`VerdictResponse\` in \`lib/types.ts\`
- [ ] After #22 lands, manually verify \`?demo=1\` + clicking each preset returns the corresponding cached payload (1.5s simulated delay, "Cached response" badge)

## Note on parallel work

Codex's PR #22 already implements the \`?demo=1\` toggle on \`feat/demo-mode-toggle\`. This PR is the second half of the pair (the cached payloads themselves), split out so the two PRs can be reviewed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)