### PR TITLE
addressed issue 16

### DIFF
--- a/lib/analyze.ts
+++ b/lib/analyze.ts
@@ -5,7 +5,7 @@ import { GoogleGenAI } from "@google/genai";
 import type { AnalyzeRequest } from "./request.ts";
 import { INCIDENT_TO_LAW } from "./types.ts";
 import type { IncidentType, VerdictResponse } from "./types.ts";
-import { uploadCloudinaryToGemini, deleteUploaded } from "./gemini/upload.ts";
+import { uploadCloudinaryToGemini, uploadLocalFileToGemini, deleteUploaded } from "./gemini/upload.ts";
 import { runPass1 } from "./gemini/pass1.ts";
 import { runPass2 } from "./gemini/pass2.ts";
 import { retrieve } from "./retrieval/index.ts";
@@ -23,8 +23,14 @@ export async function analyze(req: AnalyzeRequest): Promise<AnalyzeOutcome> {
   if (!apiKey) throw new Error("GEMINI_API_KEY not set");
   const ai = new GoogleGenAI({ apiKey });
 
-  // (1) Upload Cloudinary clip to Gemini File API. Reused across both passes.
-  const clip = await uploadCloudinaryToGemini(ai, req.cloudinaryUrl);
+  // (1) Upload the clip to Gemini File API. Local eval clips can skip Cloudinary.
+  const clip = req.localClipPath
+    ? await uploadLocalFileToGemini(ai, req.localClipPath)
+    : req.cloudinaryUrl
+    ? await uploadCloudinaryToGemini(ai, req.cloudinaryUrl)
+    : (() => {
+        throw new Error("analyze requires either localClipPath or cloudinaryUrl");
+      })();
 
   try {
     // (2) Pass 1 (skipped if user supplied a manual incident type).

--- a/lib/gemini/upload.ts
+++ b/lib/gemini/upload.ts
@@ -2,6 +2,7 @@
 // become ACTIVE. The same file handle is then reused across Pass 1 and Pass 2
 // (PRD §9 — avoids double-uploading).
 
+import { readFile } from "fs/promises";
 import { GoogleGenAI } from "@google/genai";
 
 const POLL_INTERVAL_MS = 2_000;
@@ -50,6 +51,48 @@ export async function uploadCloudinaryToGemini(
   // Blob is supported in @google/genai's Node upload path; lets us avoid a
   // /tmp file write inside the Netlify Function.
   const blob = new Blob([arrayBuffer], { type: "video/mp4" });
+
+  const uploaded = await ai.files.upload({
+    file: blob,
+    config: { mimeType: "video/mp4" },
+  });
+  if (!uploaded.name) throw new Error("Gemini upload returned no file name");
+
+  const start = Date.now();
+  let current = uploaded;
+  while (current.state === "PROCESSING") {
+    if (Date.now() - start > POLL_TIMEOUT_MS) {
+      throw new Error(`Timeout waiting for Gemini file ${current.name} to become ACTIVE`);
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    current = await ai.files.get({ name: current.name as string });
+  }
+
+  if (current.state === "FAILED") {
+    throw new Error(`Gemini file processing FAILED: ${current.name}`);
+  }
+  if (!current.uri || !current.mimeType) {
+    throw new Error(`Gemini file ready but missing uri/mimeType: ${current.name}`);
+  }
+
+  return {
+    name: current.name as string,
+    uri: current.uri,
+    mimeType: current.mimeType,
+  };
+}
+
+export async function uploadLocalFileToGemini(
+  ai: GoogleGenAI,
+  localClipPath: string,
+): Promise<UploadedClip> {
+  const buffer = await readFile(localClipPath);
+  if (buffer.byteLength > MAX_VIDEO_BYTES) {
+    throw new Error(
+      `Video is too large (${buffer.byteLength} bytes). Please upload a shorter clip.`,
+    );
+  }
+  const blob = new Blob([buffer], { type: "video/mp4" });
 
   const uploaded = await ai.files.upload({
     file: blob,

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -34,7 +34,8 @@ const VALID_ORIGINAL_DECISIONS: ReadonlyArray<OriginalRefereeDecision> = [
 ];
 
 export interface AnalyzeRequest {
-  cloudinaryUrl: string;
+  cloudinaryUrl?: string;
+  localClipPath?: string;
   originalDecision: OriginalRefereeDecision;
   incidentType: IncidentType | "auto_detect";
   promptVersion?: string;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test \"lib/**/*.test.ts\"",
+    "eval": "tsx scripts/eval/run-eval.ts",
     "spike:gemini-video": "tsx scripts/spike/gemini-video.ts"
   },
   "dependencies": {

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -1,0 +1,116 @@
+import { access, readFile } from "fs/promises";
+import path from "path";
+import { analyze } from "../../lib/analyze.ts";
+import type { OriginalRefereeDecision, RetrievalSource, Verdict } from "../../lib/types.ts";
+
+interface GroundTruthEntry {
+  id: string;
+  filename: string;
+  original_referee_decision: OriginalRefereeDecision;
+  expected_verdict: Verdict;
+  expected_law: string;
+  expected_incident_type: string;
+}
+
+interface EvalResult {
+  id: string;
+  verdictCorrect: boolean;
+  lawCorrect: boolean;
+  incidentCorrect: boolean;
+  retrievalGrounded: boolean;
+  retrievalSource: RetrievalSource;
+}
+
+const RETRIEVAL_SOURCES: RetrievalSource[] = ["vertex", "fallback", "none"];
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+async function loadGroundTruth(): Promise<GroundTruthEntry[]> {
+  const groundTruthPath = path.resolve(process.cwd(), "test-clips", "ground-truth.json");
+  let raw: string;
+  try {
+    raw = await readFile(groundTruthPath, "utf8");
+  } catch (error) {
+    throw new Error(`Unable to read ground-truth file at ${groundTruthPath}: ${(error as Error).message}`);
+  }
+
+  try {
+    return JSON.parse(raw) as GroundTruthEntry[];
+  } catch (error) {
+    throw new Error(`Invalid JSON in ${groundTruthPath}: ${(error as Error).message}`);
+  }
+}
+
+async function runEval() {
+  const groundTruth = await loadGroundTruth();
+  const testClipsDir = path.resolve(process.cwd(), "test-clips", "clips");
+  const results: EvalResult[] = [];
+
+  for (const clip of groundTruth) {
+    const clipPath = path.join(testClipsDir, clip.filename);
+
+    try {
+      await access(clipPath);
+    } catch {
+      throw new Error(`Missing clip file for ${clip.id}: ${clipPath}`);
+    }
+
+    const outcome = await analyze({
+      localClipPath: clipPath,
+      originalDecision: clip.original_referee_decision,
+      incidentType: "auto_detect",
+    });
+
+    const verdictCorrect = outcome.response.verdict === clip.expected_verdict;
+    const lawCorrect = outcome.response.rule_applied?.law_number === clip.expected_law;
+    const incidentCorrect = outcome.response.detected_incident_type === clip.expected_incident_type;
+    const retrievalGrounded = (outcome.response.rule_applied?.retrieved_chunk_ids?.length ?? 0) > 0;
+    const retrievalSource: RetrievalSource = RETRIEVAL_SOURCES.includes(outcome.response.retrieval_source)
+      ? outcome.response.retrieval_source
+      : "none";
+
+    results.push({
+      id: clip.id,
+      verdictCorrect,
+      lawCorrect,
+      incidentCorrect,
+      retrievalGrounded,
+      retrievalSource,
+    });
+
+    console.log(
+      `${clip.id}: verdict=${verdictCorrect ? "PASS" : "FAIL"}, law=${lawCorrect ? "PASS" : "FAIL"}, retrieval_source=${retrievalSource}`,
+    );
+  }
+
+  const total = results.length;
+  const verdictAccuracy = results.filter((r) => r.verdictCorrect).length / total;
+  const lawAccuracy = results.filter((r) => r.lawCorrect).length / total;
+  const groundedRate = results.filter((r) => r.retrievalGrounded).length / total;
+
+  console.log("");
+  console.log(`Verdict accuracy: ${formatPercent(verdictAccuracy)}`);
+  console.log(`Law classification accuracy: ${formatPercent(lawAccuracy)}`);
+  console.log(`Retrieval grounded: ${formatPercent(groundedRate)}`);
+  console.log("");
+  console.log("Breakdown by retrieval_source:");
+
+  for (const source of RETRIEVAL_SOURCES) {
+    const subset = results.filter((r) => r.retrievalSource === source);
+    const count = subset.length;
+    const verdictSourceAccuracy = count ? subset.filter((r) => r.verdictCorrect).length / count : 0;
+    const lawSourceAccuracy = count ? subset.filter((r) => r.lawCorrect).length / count : 0;
+    const groundedSourceRate = count ? subset.filter((r) => r.retrievalGrounded).length / count : 0;
+
+    console.log(
+      `  ${source}: ${count} clips — verdict=${formatPercent(verdictSourceAccuracy)}, law=${formatPercent(lawSourceAccuracy)}, grounded=${formatPercent(groundedSourceRate)}`,
+    );
+  }
+}
+
+runEval().catch((error) => {
+  console.error(`ERROR: ${(error as Error).message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
✅ Added evaluation support with local clip upload and metrics reporting.

What changed

Created [run-eval.ts]
reads test-clips/ground-truth.json
calls [analyze()]
directly with [localClipPath]
reports verdict accuracy, law accuracy, retrieval grounding
outputs breakdown by [retrieval_source] (vertex / fallback / none)
detects missing clip files and exits with a clear error

Updated [package.json]
added npm run eval

Updated [request.ts]
added optional [localClipPath] to [AnalyzeRequest]

Updated [analyze.ts]
supports local-file upload via new code path
retains Cloudinary upload for normal API route usage

Updated [upload.ts]
added [uploadLocalFileToGemini()]

Validation
npm run typecheck passes

Note: the new eval runner expects test-clips/ground-truth.json and matching files under test-clips/clips/ to exist in the repo.