### PR TITLE
Fix CI: use Node --test auto-discovery instead of shell glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test \"lib/**/*.test.ts\"",
+    "test": "tsx --test",
     "spike:gemini-video": "tsx scripts/spike/gemini-video.ts"
   },
   "dependencies": {


### PR DESCRIPTION
The CI workflow added in #24 fails on \`npm test\` because the test command \`tsx --test "lib/**/*.test.ts"\` relies on shell glob expansion that bash-on-Windows performs but sh-on-Linux-CI does not. Node's \`--test\` runner with no positional args auto-discovers \`*.test.{ts,tsx,...}\` files cross-platform, which is what we want.

This was originally on the \`ci/github-actions\` branch but didn't make it into the squash merge of #24. Re-applying as a small standalone fix.

## Test plan

- [x] \`npm test\` locally → 38/38 passing
- [ ] CI run on this PR — should turn green for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)