### PR TITLE
Use Node --test auto-discovery for cross-platform CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test \"lib/**/*.test.ts\"",
+    "test": "tsx --test",
     "spike:gemini-video": "tsx scripts/spike/gemini-video.ts"
   },
   "dependencies": {


### PR DESCRIPTION
The previous \`tsx --test "lib/**/*.test.ts"\` form relied on shell glob expansion. Bash on Windows expanded it; sh on the GitHub Actions runner did not, so CI failed with
\`Could not find '/home/runner/work/rescheckAi/rescheckAi/lib/**/*.test.ts'\`.

Node's --test runner auto-discovers files matching \`*.test.{ts,tsx,...}\` when invoked with no positional args, skipping node_modules. Same set of tests run, no shell semantics involved.